### PR TITLE
Modify eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,9 @@
       "ignoreUrls": true,
       "ignoreComments": false
     }],
+    "react/require-default-props": [0],
+    "react/forbid-prop-types": [1],
+    "jsx-a11y/anchor-is-valid": [1]
   },
   "settings" : {
     "import/extensions": ["js", "jsx"]


### PR DESCRIPTION
* `react/require-default-props` when you are using redux, you basically have default options. Having two different definitions of default is ambiguous and you shouldn't be forced to do it.
* `react/forbid-prop-types` Sometimes you just need to create object based on user defined data.
* `jsx-a11y/anchor-is-valid` this is related to `tag.jsx` in #3 but in Patternfly we use `<a>` with some properties quite often.