### PR TITLE
Enable to use jsx for stories

### DIFF
--- a/scripts/storybook/config.js
+++ b/scripts/storybook/config.js
@@ -4,7 +4,7 @@ import '../../dist/vendor';
 import '../../dist/vendor.css';
 
 // automatically import all files ending in *.stories.js
-const req = require.context('../../src', true, /stories\/.*stories\.js$/);
+const req = require.context('../../src', true, /stories\/.*stories\.(js|jsx)$/);
 function loadStories() {
   req.keys().forEach(filename => req(filename));
 }


### PR DESCRIPTION
### Storybook change
When we use `.jsx` file extension for stories these stories should be included as well.