### PR TITLE
Use css to load PF react styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dist/*
 *.iws
 *.iml
 
+.out
 coverage
 yarn.lock
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "jest",
     "doc": "react-docgen",
     "storybook": "start-storybook -c scripts/storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook -c scripts/storybook -o .out"
   },
   "engines": {
     "node": ">= 6.0.0",

--- a/src/vendor.scss
+++ b/src/vendor.scss
@@ -7,4 +7,4 @@
 /**
   Patternfly React Specific Sass Extensions
 */
-@import '~patternfly-react/dist/sass/patternfly-react';
+@import '~patternfly-react/dist/css/patternfly-react.css';


### PR DESCRIPTION
### Fixes #11 
When using pf react do not use sass, but rather css so we don't have to load all sass variables. This PR fixes such issue. Also point `storybook-buil` to correct config file so we can build storybook for later use.

### UI changes
none