### PR TITLE
Add npm install before running test in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
   directories:
   - node_modules
 
-script: npm t
+script:
+- npm install
+- npm t
 
 after_success: npm run coverage


### PR DESCRIPTION
### Run install before tests
Forgot to add `npm install` into travis config file, before running tests.