### PR TITLE
Mock functions for i18n

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,7 @@
     "react"
   ],
   "rules": {
+    "no-underscore-dangle": ["error", { "allow": ["__"] }],
     "import/prefer-default-export": "off",
     "no-console": "off",
     "import/no-extraneous-dependencies": ["error", {"devDependencies": true, "optionalDependencies": true, "peerDependencies": true}],
@@ -26,7 +27,9 @@
   },
   "globals": {
     "window": true,
-    "document": true
+    "document": true,
+    "__": true,
+    "sprintf": true
   },
   "env": {
     "node": true,

--- a/demo/demo-app.jsx
+++ b/demo/demo-app.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Form, Field } from 'react-final-form';
 import { Form as PfForm, Col, Row, Button, Grid } from 'patternfly-react';
 import { FinalFormSwitch } from '../src/forms';
+import { translate, sprintf } from '../src/global-functions';
 
 const onSubmit = values => console.log('onSubmit: ', values);
 
@@ -30,7 +31,7 @@ const wrapperComponent = () => (
           </Row>
           <Row>
             <Col xs={12}>
-              <Button type="submit">Submit</Button>
+              <Button type="submit">{translate(sprintf('Mask $d'), 21)}</Button>
             </Col>
           </Row>
         </PfForm>

--- a/demo/demo-app.jsx
+++ b/demo/demo-app.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { Form, Field } from 'react-final-form';
 import { Form as PfForm, Col, Row, Button, Grid } from 'patternfly-react';
 import { FinalFormSwitch } from '../src/forms';
-import { translate, sprintf } from '../src/global-functions';
 
 const onSubmit = values => console.log('onSubmit: ', values);
 
@@ -31,7 +30,7 @@ const wrapperComponent = () => (
           </Row>
           <Row>
             <Col xs={12}>
-              <Button type="submit">{translate(sprintf('Mask $d'), 21)}</Button>
+              <Button type="submit">Submit</Button>
             </Col>
           </Row>
         </PfForm>

--- a/src/global-functions/index.js
+++ b/src/global-functions/index.js
@@ -1,4 +1,4 @@
-export function translate(translateThis) {
+export function __(translateThis) {
   if (window.__) {
     return window.__(translateThis);
   }

--- a/src/global-functions/index.js
+++ b/src/global-functions/index.js
@@ -1,0 +1,13 @@
+export function translate(translateThis) {
+  if (window.__) {
+    return window.__(translateThis);
+  }
+  return translateThis;
+}
+
+export function sprintf(mask, ...rest) {
+  if (window.sprintf) {
+    return window.sprintf(mask, ...rest);
+  }
+  return mask;
+}

--- a/src/global-functions/test/translationMock.test.js
+++ b/src/global-functions/test/translationMock.test.js
@@ -1,0 +1,37 @@
+import { translate, sprintf } from '../';
+
+describe('Should provide correct translation functions', () => {
+  afterEach(() => {
+    window.__ = undefined;
+    window.sprintf = undefined;
+  });
+
+  it('Translate should not translate string ', () => {
+    const foo = 'Some string';
+    expect(translate(foo)).toEqual(foo);
+  });
+
+  it('Translate should provide string transformation if __ fuction is on window', () => {
+    const foo = 'foo';
+    const expectedResult = 'foo and some transformation';
+    window.__ = string => `${string} and some transformation`;
+    expect(window.__(foo)).toEqual(expectedResult);
+    window.__ = undefined;
+  });
+
+  it('Sprintf should not transform mask and string', () => {
+    const mask = 'Some mask %d';
+    const parameters = 10;
+    expect(sprintf(mask, parameters)).toEqual(mask);
+    expect(sprintf(translate(mask), 'foo', 'bar')).toEqual(mask);
+  });
+
+  it('Sprintf should transform string if sprintf function is on window', () => {
+    const mask = 'Some mask %d';
+    const parameter = 10;
+    const expectedResult = 'Some mask 10';
+    window.sprintf = (stringMaks, stringParameter) => stringMaks.replace('%d', stringParameter);
+    expect(sprintf(mask, parameter)).toEqual(expectedResult);
+    window.sprintf = undefined;
+  });
+});

--- a/src/global-functions/test/translationMock.test.js
+++ b/src/global-functions/test/translationMock.test.js
@@ -1,4 +1,4 @@
-import { translate, sprintf } from '../';
+import { __, sprintf } from '../';
 
 describe('Should provide correct translation functions', () => {
   afterEach(() => {
@@ -8,7 +8,7 @@ describe('Should provide correct translation functions', () => {
 
   it('Translate should not translate string ', () => {
     const foo = 'Some string';
-    expect(translate(foo)).toEqual(foo);
+    expect(__(foo)).toEqual(foo);
   });
 
   it('Translate should provide string transformation if __ fuction is on window', () => {
@@ -23,7 +23,7 @@ describe('Should provide correct translation functions', () => {
     const mask = 'Some mask %d';
     const parameters = 10;
     expect(sprintf(mask, parameters)).toEqual(mask);
-    expect(sprintf(translate(mask), 'foo', 'bar')).toEqual(mask);
+    expect(sprintf(__(mask), 'foo', 'bar')).toEqual(mask);
   });
 
   it('Sprintf should transform string if sprintf function is on window', () => {


### PR DESCRIPTION
Created a simple `translate` and `sprintf` function, that should act as a proxy for translation. These functions will work only in environment, where `__` and `sprintf` functions are available on window (as in ManageIQ). If they are not available, it will return original string or mask.