### PR TITLE
Snapshot form col fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "css-loader": "^0.28.9",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
+    "enzyme-to-json": "^3.3.4",
     "eslint": "^4.17.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-loader": "^1.9.0",

--- a/src/forms/finalFormComponent.jsx
+++ b/src/forms/finalFormComponent.jsx
@@ -11,22 +11,19 @@ const componentTypes = ['radio', 'checkbox', 'textarea', 'select', 'textfield', 
 const switchComponents = ['radio', 'checkbox'];
 const inputTypes = ['text', 'email', 'number', 'password'];
 
-const componentSelect = (componentType, props) => ({
-  textfield: <FormControl type={props.type || 'text'} {...props.input} placeholder={props.placeholder} />,
-  radio: <Radio {...props.input} >{props.label}</Radio>,
-  checkbox: <Checkbox {...props.input}>{props.label}</Checkbox>,
-  textarea: <FormControl componentClass="textarea" {...props.input} placeholder={props.placeholder} />,
+const componentSelect = (componentType, { input, meta, ...rest }) => ({
+  textfield: <FormControl type={rest.type || 'text'} {...input} placeholder={rest.placeholder} />,
+  radio: <Radio {...input} >{rest.label}</Radio>,
+  checkbox: <Checkbox {...input}>{rest.label}</Checkbox>,
+  textarea: <FormControl componentClass="textarea" {...input} placeholder={rest.placeholder} />,
   select: <ReactSelect
-    className={`${props.invalid ? 'has-error' : ''} final-form-select`}
+    className={`${rest.invalid ? 'has-error' : ''} final-form-select`}
     optionClassName="final-form-select-option"
-    options={props.options}
-    clearable={props.clearable}
-    searchable={false}
-    placeholder={props.placeholder}
-    {...props.input}
-    onChange={({ value }) => props.input.onChange(value)}
+    {...input}
+    onChange={({ value }) => input.onChange(value)}
+    {...rest}
   />,
-  switch: <Switch {...props.input} value={!!props.input.value} onChange={(elem, state) => props.input.onChange(state)} />,
+  switch: <Switch {...input} value={!!input.value} onChange={(elem, state) => input.onChange(state)} {...rest} />,
 })[componentType];
 
 const isSwitchInput = componentType => switchComponents.includes(componentType);
@@ -115,6 +112,7 @@ FinalFormComponent.propTypes = {
   componentType: componentTypeProp,
   placeholder: PropTypes.string,
   type: inputTypeProp,
+  searchable: PropTypes.bool,
 };
 
 FinalFormComponent.defaultProps = {
@@ -124,6 +122,7 @@ FinalFormComponent.defaultProps = {
   placeholder: '',
   componentType: 'textfield',
   clearable: false,
+  searchable: false,
 };
 
 export const FinalFormField = props => <FinalFormComponent componentType="textfield" {...props} />;

--- a/src/vm-snapshot-form/snapshot-form/snapshotForm.jsx
+++ b/src/vm-snapshot-form/snapshot-form/snapshotForm.jsx
@@ -47,6 +47,8 @@ export const VmSnapshotForm = ({
               id="snap_memory"
               component={FinalFormSwitch}
               label={labels.snapMemory}
+              onText="Yes"
+              offText="No"
             />
             <hr />
           </Col>

--- a/src/vm-snapshot-form/snapshot-form/snapshotForm.jsx
+++ b/src/vm-snapshot-form/snapshot-form/snapshotForm.jsx
@@ -4,7 +4,7 @@ import { Form as PfForm, Button, Col, Row, ButtonGroup } from 'patternfly-react'
 import PropTypes from 'prop-types';
 import { required } from 'redux-form-validators';
 
-import { renderFinalFormField, renderFinalFormTextArea, renderFinalFormCheckBox } from '../../forms/';
+import { renderFinalFormField, renderFinalFormTextArea, FinalFormSwitch } from '../../forms/';
 
 export const VmSnapshotForm = ({
   onSubmit,
@@ -17,6 +17,9 @@ export const VmSnapshotForm = ({
 }) => (
   <Form
     onSubmit={onSubmit}
+    initialValues={{
+      snap_memory: false,
+    }}
     render={({ invalid, values, handleSubmit }) => (
       <PfForm horizontal>
         <Row>
@@ -29,17 +32,21 @@ export const VmSnapshotForm = ({
                 render={({ input, meta }) => renderFinalFormField(input, meta, labels.name, true)}
               />
             }
+          </Col>
+          <Col xs={12}>
             <Field
               name="description"
               id="description"
               validate={descriptionRequired && required({ msg: errorMessages.description })}
               render={({ input, meta }) => renderFinalFormTextArea(input, meta, labels.description, true)}
             />
+          </Col>
+          <Col xs={12}>
             <Field
               name="snap_memory"
               id="snap_memory"
-              type="checkbox"
-              render={({ input, meta }) => renderFinalFormCheckBox(input, meta, labels.snapMemory, true)}
+              component={FinalFormSwitch}
+              label={labels.snapMemory}
             />
             <hr />
           </Col>

--- a/src/vm-snapshot-form/snapshot-form/tests/__snapshots__/snapshotForm.test.jsx.snap
+++ b/src/vm-snapshot-form/snapshot-form/tests/__snapshots__/snapshotForm.test.jsx.snap
@@ -130,6 +130,7 @@ exports[`Final form input component Should render correctly 1`] = `
                         }
                       }
                       placeholder=""
+                      searchable={false}
                       validateOnMount={true}
                     >
                       <FormGroup
@@ -271,6 +272,7 @@ exports[`Final form input component Should render correctly 1`] = `
                         }
                       }
                       placeholder=""
+                      searchable={false}
                       validateOnMount={true}
                     >
                       <FormGroup
@@ -343,6 +345,8 @@ exports[`Final form input component Should render correctly 1`] = `
                   id="snap_memory"
                   label="Snap memory"
                   name="snap_memory"
+                  offText="No"
+                  onText="Yes"
                   parse={[Function]}
                 >
                   <FinalFormSwitch
@@ -375,6 +379,8 @@ exports[`Final form input component Should render correctly 1`] = `
                         "visited": false,
                       }
                     }
+                    offText="No"
+                    onText="Yes"
                   >
                     <FinalFormComponent
                       clearable={false}
@@ -410,7 +416,10 @@ exports[`Final form input component Should render correctly 1`] = `
                           "visited": false,
                         }
                       }
+                      offText="No"
+                      onText="Yes"
                       placeholder=""
+                      searchable={false}
                       validateOnMount={false}
                     >
                       <FormGroup
@@ -444,27 +453,32 @@ exports[`Final form input component Should render correctly 1`] = `
                                 animate={true}
                                 baseClass="bootstrap-switch"
                                 bsSize={null}
+                                clearable={false}
                                 defaultValue={true}
                                 disabled={false}
                                 handleWidth="auto"
+                                id="snap_memory"
                                 inverse={false}
+                                label="Snap memory"
                                 labelText=" "
                                 labelWidth="auto"
                                 name="snap_memory"
                                 offColor="default"
-                                offText="OFF"
+                                offText="No"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onColor="primary"
                                 onFocus={[Function]}
-                                onText="ON"
+                                onText="Yes"
+                                placeholder=""
                                 readonly={false}
+                                searchable={false}
                                 tristate={false}
                                 value={false}
                                 wrapperClass="wrapper"
                               >
                                 <div
-                                  className="bootstrap-switch wrapper bootstrap-switch-off"
+                                  className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-snap_memory"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
@@ -493,7 +507,7 @@ exports[`Final form input component Should render correctly 1`] = `
                                         }
                                       }
                                     >
-                                      ON
+                                      Yes
                                     </span>
                                     <span
                                       className="bootstrap-switch-label"
@@ -521,7 +535,7 @@ exports[`Final form input component Should render correctly 1`] = `
                                         }
                                       }
                                     >
-                                      OFF
+                                      No
                                     </span>
                                   </div>
                                 </div>
@@ -734,6 +748,7 @@ exports[`Final form input component Should render with description required 1`] 
                         }
                       }
                       placeholder=""
+                      searchable={false}
                       validateOnMount={true}
                     >
                       <FormGroup
@@ -875,6 +890,7 @@ exports[`Final form input component Should render with description required 1`] 
                         }
                       }
                       placeholder=""
+                      searchable={false}
                       validateOnMount={true}
                     >
                       <FormGroup
@@ -956,6 +972,8 @@ exports[`Final form input component Should render with description required 1`] 
                   id="snap_memory"
                   label="Snap memory"
                   name="snap_memory"
+                  offText="No"
+                  onText="Yes"
                   parse={[Function]}
                 >
                   <FinalFormSwitch
@@ -988,6 +1006,8 @@ exports[`Final form input component Should render with description required 1`] 
                         "visited": false,
                       }
                     }
+                    offText="No"
+                    onText="Yes"
                   >
                     <FinalFormComponent
                       clearable={false}
@@ -1023,7 +1043,10 @@ exports[`Final form input component Should render with description required 1`] 
                           "visited": false,
                         }
                       }
+                      offText="No"
+                      onText="Yes"
                       placeholder=""
+                      searchable={false}
                       validateOnMount={false}
                     >
                       <FormGroup
@@ -1057,27 +1080,32 @@ exports[`Final form input component Should render with description required 1`] 
                                 animate={true}
                                 baseClass="bootstrap-switch"
                                 bsSize={null}
+                                clearable={false}
                                 defaultValue={true}
                                 disabled={false}
                                 handleWidth="auto"
+                                id="snap_memory"
                                 inverse={false}
+                                label="Snap memory"
                                 labelText=" "
                                 labelWidth="auto"
                                 name="snap_memory"
                                 offColor="default"
-                                offText="OFF"
+                                offText="No"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onColor="primary"
                                 onFocus={[Function]}
-                                onText="ON"
+                                onText="Yes"
+                                placeholder=""
                                 readonly={false}
+                                searchable={false}
                                 tristate={false}
                                 value={false}
                                 wrapperClass="wrapper"
                               >
                                 <div
-                                  className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-animate"
+                                  className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-snap_memory bootstrap-switch-animate"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
@@ -1106,7 +1134,7 @@ exports[`Final form input component Should render with description required 1`] 
                                         }
                                       }
                                     >
-                                      ON
+                                      Yes
                                     </span>
                                     <span
                                       className="bootstrap-switch-label"
@@ -1134,7 +1162,7 @@ exports[`Final form input component Should render with description required 1`] 
                                         }
                                       }
                                     >
-                                      OFF
+                                      No
                                     </span>
                                   </div>
                                 </div>
@@ -1347,6 +1375,7 @@ exports[`Final form input component Should render with name required 1`] = `
                         }
                       }
                       placeholder=""
+                      searchable={false}
                       validateOnMount={true}
                     >
                       <FormGroup
@@ -1497,6 +1526,7 @@ exports[`Final form input component Should render with name required 1`] = `
                         }
                       }
                       placeholder=""
+                      searchable={false}
                       validateOnMount={true}
                     >
                       <FormGroup
@@ -1569,6 +1599,8 @@ exports[`Final form input component Should render with name required 1`] = `
                   id="snap_memory"
                   label="Snap memory"
                   name="snap_memory"
+                  offText="No"
+                  onText="Yes"
                   parse={[Function]}
                 >
                   <FinalFormSwitch
@@ -1601,6 +1633,8 @@ exports[`Final form input component Should render with name required 1`] = `
                         "visited": false,
                       }
                     }
+                    offText="No"
+                    onText="Yes"
                   >
                     <FinalFormComponent
                       clearable={false}
@@ -1636,7 +1670,10 @@ exports[`Final form input component Should render with name required 1`] = `
                           "visited": false,
                         }
                       }
+                      offText="No"
+                      onText="Yes"
                       placeholder=""
+                      searchable={false}
                       validateOnMount={false}
                     >
                       <FormGroup
@@ -1670,27 +1707,32 @@ exports[`Final form input component Should render with name required 1`] = `
                                 animate={true}
                                 baseClass="bootstrap-switch"
                                 bsSize={null}
+                                clearable={false}
                                 defaultValue={true}
                                 disabled={false}
                                 handleWidth="auto"
+                                id="snap_memory"
                                 inverse={false}
+                                label="Snap memory"
                                 labelText=" "
                                 labelWidth="auto"
                                 name="snap_memory"
                                 offColor="default"
-                                offText="OFF"
+                                offText="No"
                                 onBlur={[Function]}
                                 onChange={[Function]}
                                 onColor="primary"
                                 onFocus={[Function]}
-                                onText="ON"
+                                onText="Yes"
+                                placeholder=""
                                 readonly={false}
+                                searchable={false}
                                 tristate={false}
                                 value={false}
                                 wrapperClass="wrapper"
                               >
                                 <div
-                                  className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-animate"
+                                  className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-snap_memory bootstrap-switch-animate"
                                   onBlur={[Function]}
                                   onFocus={[Function]}
                                   onKeyDown={[Function]}
@@ -1719,7 +1761,7 @@ exports[`Final form input component Should render with name required 1`] = `
                                         }
                                       }
                                     >
-                                      ON
+                                      Yes
                                     </span>
                                     <span
                                       className="bootstrap-switch-label"
@@ -1747,7 +1789,7 @@ exports[`Final form input component Should render with name required 1`] = `
                                         }
                                       }
                                     >
-                                      OFF
+                                      No
                                     </span>
                                   </div>
                                 </div>

--- a/src/vm-snapshot-form/snapshot-form/tests/__snapshots__/snapshotForm.test.jsx.snap
+++ b/src/vm-snapshot-form/snapshot-form/tests/__snapshots__/snapshotForm.test.jsx.snap
@@ -1,365 +1,1831 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Final form input component Should render correctly 1`] = `
-<form
-  className="form-horizontal"
+<VmSnapshotForm
+  descriptionRequired={false}
+  errorMessages={
+    Object {
+      "description": "Description required",
+      "name": "Name required",
+    }
+  }
+  hideName={false}
+  labels={
+    Object {
+      "cancel": "Cancel",
+      "create": "Create",
+      "description": "Input description",
+      "name": "Input name",
+      "snapMemory": "Snap memory",
+    }
+  }
+  nameRequired={false}
+  onCancel={[MockFunction]}
+  onSubmit={[MockFunction]}
+  validateOnMount={true}
 >
-  <div
-    className="row"
+  <ReactFinalForm
+    initialValues={
+      Object {
+        "snap_memory": false,
+      }
+    }
+    onSubmit={[MockFunction]}
+    render={[Function]}
   >
-    <div
-      className="col-xs-12"
+    <Form
+      bsClass="form"
+      componentClass="form"
+      horizontal={true}
+      inline={false}
     >
-      <div
-        className="form-group"
+      <form
+        className="form-horizontal"
       >
-        <label
-          className="control-label col-xs-2"
-        >
-          Input name
-        </label>
-        <div
-          className="col-xs-8"
-        >
-          <input
-            className="form-control"
-            id={undefined}
-            name="name"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="form-group"
-      >
-        <label
-          className="control-label col-xs-2"
-        >
-          Input description
-        </label>
-        <div
-          className="col-xs-8"
-        >
-          <textarea
-            className="form-control"
-            id={undefined}
-            name="description"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            type={undefined}
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="field-group form-group"
-      >
-        <div
-          className=""
+        <Row
+          bsClass="row"
+          componentClass="div"
         >
           <div
-            className="checkbox"
-            style={undefined}
+            className="row"
           >
-            <label
-              title=""
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
             >
-              <input
-                checked={false}
-                disabled={false}
-                name="snap_memory"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="checkbox"
-                value=""
-              />
-              Snap memory
-            </label>
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  format={[Function]}
+                  id="name"
+                  name="name"
+                  parse={[Function]}
+                  render={[Function]}
+                  validate={false}
+                >
+                  <FinalFormField
+                    input={
+                      Object {
+                        "name": "name",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    label="Input name"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    validateOnMount={true}
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="textfield"
+                      input={
+                        Object {
+                          "name": "name",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Input name"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": undefined,
+                          "invalid": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={true}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState={null}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Input name
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <FormControl
+                                bsClass="form-control"
+                                componentClass="input"
+                                name="name"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                type="text"
+                                value=""
+                              >
+                                <input
+                                  className="form-control"
+                                  name="name"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder=""
+                                  type="text"
+                                  value=""
+                                />
+                              </FormControl>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormField>
+                </Field>
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  format={[Function]}
+                  id="description"
+                  name="description"
+                  parse={[Function]}
+                  render={[Function]}
+                  validate={false}
+                >
+                  <FinalFormTextArea
+                    input={
+                      Object {
+                        "name": "description",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    label="Input description"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    validateOnMount={true}
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="textarea"
+                      input={
+                        Object {
+                          "name": "description",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Input description"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": undefined,
+                          "invalid": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={true}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState={null}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Input description
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <FormControl
+                                bsClass="form-control"
+                                componentClass="textarea"
+                                name="description"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                value=""
+                              >
+                                <textarea
+                                  className="form-control"
+                                  name="description"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder=""
+                                  value=""
+                                />
+                              </FormControl>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormTextArea>
+                </Field>
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  component={[Function]}
+                  format={[Function]}
+                  id="snap_memory"
+                  label="Snap memory"
+                  name="snap_memory"
+                  parse={[Function]}
+                >
+                  <FinalFormSwitch
+                    id="snap_memory"
+                    input={
+                      Object {
+                        "name": "snap_memory",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": false,
+                      }
+                    }
+                    label="Snap memory"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": false,
+                        "invalid": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="switch"
+                      id="snap_memory"
+                      input={
+                        Object {
+                          "name": "snap_memory",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": false,
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Snap memory"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": false,
+                          "invalid": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={false}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState={null}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Snap memory
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <Switch
+                                animate={true}
+                                baseClass="bootstrap-switch"
+                                bsSize={null}
+                                defaultValue={true}
+                                disabled={false}
+                                handleWidth="auto"
+                                inverse={false}
+                                labelText=" "
+                                labelWidth="auto"
+                                name="snap_memory"
+                                offColor="default"
+                                offText="OFF"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onColor="primary"
+                                onFocus={[Function]}
+                                onText="ON"
+                                readonly={false}
+                                tristate={false}
+                                value={false}
+                                wrapperClass="wrapper"
+                              >
+                                <div
+                                  className="bootstrap-switch wrapper bootstrap-switch-off"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  style={
+                                    Object {
+                                      "width": "auto",
+                                    }
+                                  }
+                                  tabIndex="0"
+                                >
+                                  <div
+                                    className="bootstrap-switch-container"
+                                    style={
+                                      Object {
+                                        "marginLeft": -0,
+                                        "width": "auto",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="bootstrap-switch-handle-on bootstrap-switch-primary"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                      ON
+                                    </span>
+                                    <span
+                                      className="bootstrap-switch-label"
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseMove={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                       
+                                    </span>
+                                    <span
+                                      className="bootstrap-switch-handle-off bootstrap-switch-default"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                      OFF
+                                    </span>
+                                  </div>
+                                </div>
+                              </Switch>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormSwitch>
+                </Field>
+                <hr />
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  className="pull-right"
+                  justified={false}
+                  vertical={false}
+                >
+                  <div
+                    className="pull-right btn-group"
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="primary"
+                      disabled={false}
+                      id="snap-form-submit"
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="btn btn-primary"
+                        disabled={false}
+                        id="snap-form-submit"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Create
+                      </button>
+                    </Button>
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="default"
+                      disabled={false}
+                      id="snap-form-cancel"
+                      onClick={[MockFunction]}
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        id="snap-form-cancel"
+                        onClick={[MockFunction]}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                    </Button>
+                  </div>
+                </ButtonGroup>
+              </div>
+            </Col>
           </div>
-        </div>
-      </div>
-      <hr />
-    </div>
-    <div
-      className="col-xs-12"
-    >
-      <div
-        className="pull-right btn-group"
-      >
-        <button
-          className="btn btn-primary"
-          disabled={false}
-          id="snap-form-submit"
-          onClick={[Function]}
-          type="button"
-        >
-          Create
-        </button>
-        <button
-          className="btn btn-default"
-          disabled={false}
-          id="snap-form-cancel"
-          onClick={[MockFunction]}
-          type="button"
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  </div>
-</form>
+        </Row>
+      </form>
+    </Form>
+  </ReactFinalForm>
+</VmSnapshotForm>
 `;
 
 exports[`Final form input component Should render with description required 1`] = `
-<form
-  className="form-horizontal"
+<VmSnapshotForm
+  descriptionRequired={true}
+  errorMessages={
+    Object {
+      "description": "Description required",
+      "name": "Name required",
+    }
+  }
+  hideName={false}
+  labels={
+    Object {
+      "cancel": "Cancel",
+      "create": "Create",
+      "description": "Input description",
+      "name": "Input name",
+      "snapMemory": "Snap memory",
+    }
+  }
+  nameRequired={false}
+  onCancel={[MockFunction]}
+  onSubmit={[MockFunction]}
+  validateOnMount={true}
 >
-  <div
-    className="row"
+  <ReactFinalForm
+    initialValues={
+      Object {
+        "snap_memory": false,
+      }
+    }
+    onSubmit={[MockFunction]}
+    render={[Function]}
   >
-    <div
-      className="col-xs-12"
+    <Form
+      bsClass="form"
+      componentClass="form"
+      horizontal={true}
+      inline={false}
     >
-      <div
-        className="form-group"
+      <form
+        className="form-horizontal"
       >
-        <label
-          className="control-label col-xs-2"
-        >
-          Input name
-        </label>
-        <div
-          className="col-xs-8"
-        >
-          <input
-            className="form-control"
-            id={undefined}
-            name="name"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            type="text"
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="form-group has-error"
-      >
-        <label
-          className="control-label col-xs-2"
-        >
-          Input description
-        </label>
-        <div
-          className="col-xs-8"
-        >
-          <textarea
-            className="form-control"
-            id={undefined}
-            name="description"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            type={undefined}
-            value=""
-          />
-          <span
-            className="help-block"
-          >
-            Description required
-          </span>
-        </div>
-      </div>
-      <div
-        className="field-group form-group"
-      >
-        <div
-          className=""
+        <Row
+          bsClass="row"
+          componentClass="div"
         >
           <div
-            className="checkbox"
-            style={undefined}
+            className="row"
           >
-            <label
-              title=""
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
             >
-              <input
-                checked={false}
-                disabled={false}
-                name="snap_memory"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="checkbox"
-                value=""
-              />
-              Snap memory
-            </label>
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  format={[Function]}
+                  id="name"
+                  name="name"
+                  parse={[Function]}
+                  render={[Function]}
+                  validate={false}
+                >
+                  <FinalFormField
+                    input={
+                      Object {
+                        "name": "name",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    label="Input name"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    validateOnMount={true}
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="textfield"
+                      input={
+                        Object {
+                          "name": "name",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Input name"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": undefined,
+                          "invalid": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={true}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState={null}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Input name
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <FormControl
+                                bsClass="form-control"
+                                componentClass="input"
+                                name="name"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                type="text"
+                                value=""
+                              >
+                                <input
+                                  className="form-control"
+                                  name="name"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder=""
+                                  type="text"
+                                  value=""
+                                />
+                              </FormControl>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormField>
+                </Field>
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  format={[Function]}
+                  id="description"
+                  name="description"
+                  parse={[Function]}
+                  render={[Function]}
+                  validate={[Function]}
+                >
+                  <FinalFormTextArea
+                    input={
+                      Object {
+                        "name": "description",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    label="Input description"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": "Description required",
+                        "initial": undefined,
+                        "invalid": true,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": false,
+                        "visited": false,
+                      }
+                    }
+                    validateOnMount={true}
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="textarea"
+                      input={
+                        Object {
+                          "name": "description",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Input description"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": "Description required",
+                          "initial": undefined,
+                          "invalid": true,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": false,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={true}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState="error"
+                      >
+                        <div
+                          className="form-group has-error"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Input description
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <FormControl
+                                bsClass="form-control"
+                                componentClass="textarea"
+                                name="description"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                value=""
+                              >
+                                <textarea
+                                  className="form-control"
+                                  name="description"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder=""
+                                  value=""
+                                />
+                              </FormControl>
+                              <HelpBlock
+                                bsClass="help-block"
+                              >
+                                <span
+                                  className="help-block"
+                                >
+                                  Description required
+                                </span>
+                              </HelpBlock>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormTextArea>
+                </Field>
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  component={[Function]}
+                  format={[Function]}
+                  id="snap_memory"
+                  label="Snap memory"
+                  name="snap_memory"
+                  parse={[Function]}
+                >
+                  <FinalFormSwitch
+                    id="snap_memory"
+                    input={
+                      Object {
+                        "name": "snap_memory",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": false,
+                      }
+                    }
+                    label="Snap memory"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": false,
+                        "invalid": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="switch"
+                      id="snap_memory"
+                      input={
+                        Object {
+                          "name": "snap_memory",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": false,
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Snap memory"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": false,
+                          "invalid": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={false}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState={null}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Snap memory
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <Switch
+                                animate={true}
+                                baseClass="bootstrap-switch"
+                                bsSize={null}
+                                defaultValue={true}
+                                disabled={false}
+                                handleWidth="auto"
+                                inverse={false}
+                                labelText=" "
+                                labelWidth="auto"
+                                name="snap_memory"
+                                offColor="default"
+                                offText="OFF"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onColor="primary"
+                                onFocus={[Function]}
+                                onText="ON"
+                                readonly={false}
+                                tristate={false}
+                                value={false}
+                                wrapperClass="wrapper"
+                              >
+                                <div
+                                  className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-animate"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  style={
+                                    Object {
+                                      "width": "auto",
+                                    }
+                                  }
+                                  tabIndex="0"
+                                >
+                                  <div
+                                    className="bootstrap-switch-container"
+                                    style={
+                                      Object {
+                                        "marginLeft": -0,
+                                        "width": "auto",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="bootstrap-switch-handle-on bootstrap-switch-primary"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                      ON
+                                    </span>
+                                    <span
+                                      className="bootstrap-switch-label"
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseMove={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                       
+                                    </span>
+                                    <span
+                                      className="bootstrap-switch-handle-off bootstrap-switch-default"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                      OFF
+                                    </span>
+                                  </div>
+                                </div>
+                              </Switch>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormSwitch>
+                </Field>
+                <hr />
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  className="pull-right"
+                  justified={false}
+                  vertical={false}
+                >
+                  <div
+                    className="pull-right btn-group"
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="primary"
+                      disabled={true}
+                      id="snap-form-submit"
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="btn btn-primary"
+                        disabled={true}
+                        id="snap-form-submit"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Create
+                      </button>
+                    </Button>
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="default"
+                      disabled={false}
+                      id="snap-form-cancel"
+                      onClick={[MockFunction]}
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        id="snap-form-cancel"
+                        onClick={[MockFunction]}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                    </Button>
+                  </div>
+                </ButtonGroup>
+              </div>
+            </Col>
           </div>
-        </div>
-      </div>
-      <hr />
-    </div>
-    <div
-      className="col-xs-12"
-    >
-      <div
-        className="pull-right btn-group"
-      >
-        <button
-          className="btn btn-primary"
-          disabled={true}
-          id="snap-form-submit"
-          onClick={[Function]}
-          type="button"
-        >
-          Create
-        </button>
-        <button
-          className="btn btn-default"
-          disabled={false}
-          id="snap-form-cancel"
-          onClick={[MockFunction]}
-          type="button"
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  </div>
-</form>
+        </Row>
+      </form>
+    </Form>
+  </ReactFinalForm>
+</VmSnapshotForm>
 `;
 
 exports[`Final form input component Should render with name required 1`] = `
-<form
-  className="form-horizontal"
+<VmSnapshotForm
+  descriptionRequired={false}
+  errorMessages={
+    Object {
+      "description": "Description required",
+      "name": "Name required",
+    }
+  }
+  hideName={false}
+  labels={
+    Object {
+      "cancel": "Cancel",
+      "create": "Create",
+      "description": "Input description",
+      "name": "Input name",
+      "snapMemory": "Snap memory",
+    }
+  }
+  nameRequired={true}
+  onCancel={[MockFunction]}
+  onSubmit={[MockFunction]}
+  validateOnMount={true}
 >
-  <div
-    className="row"
+  <ReactFinalForm
+    initialValues={
+      Object {
+        "snap_memory": false,
+      }
+    }
+    onSubmit={[MockFunction]}
+    render={[Function]}
   >
-    <div
-      className="col-xs-12"
+    <Form
+      bsClass="form"
+      componentClass="form"
+      horizontal={true}
+      inline={false}
     >
-      <div
-        className="form-group has-error"
+      <form
+        className="form-horizontal"
       >
-        <label
-          className="control-label col-xs-2"
-        >
-          Input name
-        </label>
-        <div
-          className="col-xs-8"
-        >
-          <input
-            className="form-control"
-            id={undefined}
-            name="name"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            type="text"
-            value=""
-          />
-          <span
-            className="help-block"
-          >
-            Name required
-          </span>
-        </div>
-      </div>
-      <div
-        className="form-group"
-      >
-        <label
-          className="control-label col-xs-2"
-        >
-          Input description
-        </label>
-        <div
-          className="col-xs-8"
-        >
-          <textarea
-            className="form-control"
-            id={undefined}
-            name="description"
-            onBlur={[Function]}
-            onChange={[Function]}
-            onFocus={[Function]}
-            placeholder=""
-            type={undefined}
-            value=""
-          />
-        </div>
-      </div>
-      <div
-        className="field-group form-group"
-      >
-        <div
-          className=""
+        <Row
+          bsClass="row"
+          componentClass="div"
         >
           <div
-            className="checkbox"
-            style={undefined}
+            className="row"
           >
-            <label
-              title=""
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
             >
-              <input
-                checked={false}
-                disabled={false}
-                name="snap_memory"
-                onBlur={[Function]}
-                onChange={[Function]}
-                onFocus={[Function]}
-                type="checkbox"
-                value=""
-              />
-              Snap memory
-            </label>
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  format={[Function]}
+                  id="name"
+                  name="name"
+                  parse={[Function]}
+                  render={[Function]}
+                  validate={[Function]}
+                >
+                  <FinalFormField
+                    input={
+                      Object {
+                        "name": "name",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    label="Input name"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": "Name required",
+                        "initial": undefined,
+                        "invalid": true,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": false,
+                        "visited": false,
+                      }
+                    }
+                    validateOnMount={true}
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="textfield"
+                      input={
+                        Object {
+                          "name": "name",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Input name"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": "Name required",
+                          "initial": undefined,
+                          "invalid": true,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": false,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={true}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState="error"
+                      >
+                        <div
+                          className="form-group has-error"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Input name
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <FormControl
+                                bsClass="form-control"
+                                componentClass="input"
+                                name="name"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                type="text"
+                                value=""
+                              >
+                                <input
+                                  className="form-control"
+                                  name="name"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder=""
+                                  type="text"
+                                  value=""
+                                />
+                              </FormControl>
+                              <HelpBlock
+                                bsClass="help-block"
+                              >
+                                <span
+                                  className="help-block"
+                                >
+                                  Name required
+                                </span>
+                              </HelpBlock>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormField>
+                </Field>
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  format={[Function]}
+                  id="description"
+                  name="description"
+                  parse={[Function]}
+                  render={[Function]}
+                  validate={false}
+                >
+                  <FinalFormTextArea
+                    input={
+                      Object {
+                        "name": "description",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    label="Input description"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    validateOnMount={true}
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="textarea"
+                      input={
+                        Object {
+                          "name": "description",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": "",
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Input description"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": undefined,
+                          "invalid": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={true}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState={null}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Input description
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <FormControl
+                                bsClass="form-control"
+                                componentClass="textarea"
+                                name="description"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onFocus={[Function]}
+                                placeholder=""
+                                value=""
+                              >
+                                <textarea
+                                  className="form-control"
+                                  name="description"
+                                  onBlur={[Function]}
+                                  onChange={[Function]}
+                                  onFocus={[Function]}
+                                  placeholder=""
+                                  value=""
+                                />
+                              </FormControl>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormTextArea>
+                </Field>
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <Field
+                  component={[Function]}
+                  format={[Function]}
+                  id="snap_memory"
+                  label="Snap memory"
+                  name="snap_memory"
+                  parse={[Function]}
+                >
+                  <FinalFormSwitch
+                    id="snap_memory"
+                    input={
+                      Object {
+                        "name": "snap_memory",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": false,
+                      }
+                    }
+                    label="Snap memory"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": false,
+                        "invalid": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                  >
+                    <FinalFormComponent
+                      clearable={false}
+                      componentType="switch"
+                      id="snap_memory"
+                      input={
+                        Object {
+                          "name": "snap_memory",
+                          "onBlur": [Function],
+                          "onChange": [Function],
+                          "onFocus": [Function],
+                          "value": false,
+                        }
+                      }
+                      inputColumnSize={8}
+                      label="Snap memory"
+                      labelColumnSize={2}
+                      meta={
+                        Object {
+                          "active": false,
+                          "data": Object {},
+                          "dirty": false,
+                          "dirtySinceLastSubmit": false,
+                          "error": undefined,
+                          "initial": false,
+                          "invalid": false,
+                          "pristine": true,
+                          "submitError": undefined,
+                          "submitFailed": false,
+                          "submitSucceeded": false,
+                          "touched": false,
+                          "valid": true,
+                          "visited": false,
+                        }
+                      }
+                      placeholder=""
+                      validateOnMount={false}
+                    >
+                      <FormGroup
+                        bsClass="form-group"
+                        validationState={null}
+                      >
+                        <div
+                          className="form-group"
+                        >
+                          <Col
+                            bsClass="col"
+                            className="control-label"
+                            componentClass="label"
+                            xs={2}
+                          >
+                            <label
+                              className="control-label col-xs-2"
+                            >
+                              Snap memory
+                            </label>
+                          </Col>
+                          <Col
+                            bsClass="col"
+                            componentClass="div"
+                            xs={8}
+                          >
+                            <div
+                              className="col-xs-8"
+                            >
+                              <Switch
+                                animate={true}
+                                baseClass="bootstrap-switch"
+                                bsSize={null}
+                                defaultValue={true}
+                                disabled={false}
+                                handleWidth="auto"
+                                inverse={false}
+                                labelText=" "
+                                labelWidth="auto"
+                                name="snap_memory"
+                                offColor="default"
+                                offText="OFF"
+                                onBlur={[Function]}
+                                onChange={[Function]}
+                                onColor="primary"
+                                onFocus={[Function]}
+                                onText="ON"
+                                readonly={false}
+                                tristate={false}
+                                value={false}
+                                wrapperClass="wrapper"
+                              >
+                                <div
+                                  className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-animate"
+                                  onBlur={[Function]}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  style={
+                                    Object {
+                                      "width": "auto",
+                                    }
+                                  }
+                                  tabIndex="0"
+                                >
+                                  <div
+                                    className="bootstrap-switch-container"
+                                    style={
+                                      Object {
+                                        "marginLeft": -0,
+                                        "width": "auto",
+                                      }
+                                    }
+                                  >
+                                    <span
+                                      className="bootstrap-switch-handle-on bootstrap-switch-primary"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                      ON
+                                    </span>
+                                    <span
+                                      className="bootstrap-switch-label"
+                                      onMouseDown={[Function]}
+                                      onMouseLeave={[Function]}
+                                      onMouseMove={[Function]}
+                                      onMouseUp={[Function]}
+                                      onTouchEnd={[Function]}
+                                      onTouchMove={[Function]}
+                                      onTouchStart={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                       
+                                    </span>
+                                    <span
+                                      className="bootstrap-switch-handle-off bootstrap-switch-default"
+                                      onClick={[Function]}
+                                      style={
+                                        Object {
+                                          "width": 0,
+                                        }
+                                      }
+                                    >
+                                      OFF
+                                    </span>
+                                  </div>
+                                </div>
+                              </Switch>
+                            </div>
+                          </Col>
+                        </div>
+                      </FormGroup>
+                    </FinalFormComponent>
+                  </FinalFormSwitch>
+                </Field>
+                <hr />
+              </div>
+            </Col>
+            <Col
+              bsClass="col"
+              componentClass="div"
+              xs={12}
+            >
+              <div
+                className="col-xs-12"
+              >
+                <ButtonGroup
+                  block={false}
+                  bsClass="btn-group"
+                  className="pull-right"
+                  justified={false}
+                  vertical={false}
+                >
+                  <div
+                    className="pull-right btn-group"
+                  >
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="primary"
+                      disabled={true}
+                      id="snap-form-submit"
+                      onClick={[Function]}
+                    >
+                      <button
+                        className="btn btn-primary"
+                        disabled={true}
+                        id="snap-form-submit"
+                        onClick={[Function]}
+                        type="button"
+                      >
+                        Create
+                      </button>
+                    </Button>
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
+                      bsStyle="default"
+                      disabled={false}
+                      id="snap-form-cancel"
+                      onClick={[MockFunction]}
+                    >
+                      <button
+                        className="btn btn-default"
+                        disabled={false}
+                        id="snap-form-cancel"
+                        onClick={[MockFunction]}
+                        type="button"
+                      >
+                        Cancel
+                      </button>
+                    </Button>
+                  </div>
+                </ButtonGroup>
+              </div>
+            </Col>
           </div>
-        </div>
-      </div>
-      <hr />
-    </div>
-    <div
-      className="col-xs-12"
-    >
-      <div
-        className="pull-right btn-group"
-      >
-        <button
-          className="btn btn-primary"
-          disabled={true}
-          id="snap-form-submit"
-          onClick={[Function]}
-          type="button"
-        >
-          Create
-        </button>
-        <button
-          className="btn btn-default"
-          disabled={false}
-          id="snap-form-cancel"
-          onClick={[MockFunction]}
-          type="button"
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  </div>
-</form>
+        </Row>
+      </form>
+    </Form>
+  </ReactFinalForm>
+</VmSnapshotForm>
 `;

--- a/src/vm-snapshot-form/snapshot-form/tests/snapshotForm.test.jsx
+++ b/src/vm-snapshot-form/snapshot-form/tests/snapshotForm.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import renderer from 'react-test-renderer';
-import { VmSnapshotForm } from '../snapshotForm';
+import toJson from 'enzyme-to-json';
+import { VmSnapshotForm } from '../../';
 
 describe('Final form input component', () => {
   const initialProps = {};
@@ -23,18 +23,18 @@ describe('Final form input component', () => {
   });
 
   it('Should render correctly', () => {
-    const tree = renderer.create(<VmSnapshotForm {...initialProps} />).toJSON();
-    expect(tree).toMatchSnapshot();
+    const tree = mount(<VmSnapshotForm {...initialProps} />);
+    expect(toJson(tree)).toMatchSnapshot();
   });
 
   it('Should render with name required', () => {
-    const tree = renderer.create(<VmSnapshotForm {...initialProps} nameRequired />).toJSON();
-    expect(tree).toMatchSnapshot();
+    const tree = mount(<VmSnapshotForm {...initialProps} nameRequired />);
+    expect(toJson(tree)).toMatchSnapshot();
   });
 
   it('Should render with description required', () => {
-    const tree = renderer.create(<VmSnapshotForm {...initialProps} descriptionRequired />).toJSON();
-    expect(tree).toMatchSnapshot();
+    const tree = mount(<VmSnapshotForm {...initialProps} descriptionRequired />);
+    expect(toJson(tree)).toMatchSnapshot();
   });
 
   it('Submit button should be disabled', () => {


### PR DESCRIPTION
Replaced single checkbox witch switch component and fixed its horizontal alignment.

I have also encountered a issue with react-test-renderer. It was creating a error `Uncaught TypeError: Cannot read property 'offsetWidth' of null`, while i was trying to create a snapshot of the Switch component. Have no idea what was causing it. We don't actually need that renderer, we can use `shallow` and `mount` from enzyme and some serializer. I have added `enzyme-to-json` package and that works just fine.
