### PR TITLE
Fix storybook build by extending default build config

### DIFF
--- a/scripts/rules.js
+++ b/scripts/rules.js
@@ -1,0 +1,46 @@
+const ExtractTextPlugin = require('mini-css-extract-plugin');
+
+const rules = [
+  {
+    enforce: 'pre',
+    test: /\.(js|jsx)$/,
+    exclude: [
+      /node_modules/,
+      /\/data\//,
+      /\/stories\/|/,
+      /vendor.js/,
+    ],
+    loader: 'eslint-loader',
+  },
+  {
+    test: /\.(js|jsx)$/,
+    loader: 'babel-loader',
+    exclude: /node_modules/,
+  },
+  {
+    test: /\.(ts|tsx)$/,
+    loader: 'awesome-typescript-loader',
+  },
+  {
+    test: /\.(png|jpg|gif|svg|woff|ttf|eot)/,
+    loader: 'url-loader?limit=20480&name=static/[name].[ext]',
+  },
+  {
+    test: /\.(sa|sc|c)ss$/,
+    exclude: /node_modules/,
+    use: [
+      ExtractTextPlugin.loader,
+      {
+        loader: 'css-loader',
+      },
+      {
+        loader: 'resolve-url-loader',
+      },
+      {
+        loader: 'sass-loader',
+      },
+    ],
+  },
+];
+
+module.exports = rules;

--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -5,8 +5,8 @@
 // IMPORTANT
 // When you add this file, we won't add the default configurations which is similar
 // to "React Create App". This only has babel loader to load JavaScript.
-const ExtractTextPlugin = require('mini-css-extract-plugin');
 const plugins = require('../plugins');
+const rules = require('../rules');
 
 module.exports = {
   plugins: [
@@ -14,6 +14,7 @@ module.exports = {
   ],
   module: {
     rules: [
+      ...rules,
       {
         test: /\.stories\.js$/,
         loaders: [
@@ -29,30 +30,11 @@ module.exports = {
         enforce: 'pre',
       },
       {
-        test: /\.(sa|sc|c)ss$/,
-        exclude: /node_modules/,
-        use: [
-          ExtractTextPlugin.loader,
-          {
-            loader: 'css-loader',
-          },
-          {
-            loader: 'resolve-url-loader',
-          },
-          {
-            loader: 'sass-loader',
-          },
-        ],
-      },
-      {
-        test: /\.(png|jpg|gif|svg|woff|ttf|eot)/,
-        loader: 'url-loader?limit=20480&name=static/[name].[ext]',
-      },
-      {
         test: /\.stories\.(js|jsx)$/,
         loaders: [require.resolve('@storybook/addon-storysource/loader')],
         enforce: 'pre',
       },
     ],
   },
+  resolve: { extensions: ['.js', '.jsx'] },
 };

--- a/scripts/webpack.config.js
+++ b/scripts/webpack.config.js
@@ -1,9 +1,9 @@
 const { resolve } = require('path');
-const ExtractTextPlugin = require('mini-css-extract-plugin');
 const { fileEntries, buildExternals, FILE_NAMES } = require('./helper-functions');
 
 const devMode = process.env.NODE_ENV !== 'production';
 const plugins = require('./plugins');
+const rules = require('./rules');
 
 module.exports = (env) => {
   const isBuild = env && env.build;
@@ -27,43 +27,7 @@ module.exports = (env) => {
     },
     plugins: Object.keys(appPlugins).map(pluginName => appPlugins[pluginName]),
     module: {
-      rules: [
-        {
-          enforce: 'pre',
-          test: /\.(js|jsx)$/,
-          exclude: /node_modules/,
-          loader: 'eslint-loader',
-        },
-        {
-          test: /\.(js|jsx)$/,
-          loader: 'babel-loader',
-          exclude: /node_modules/,
-        },
-        {
-          test: /\.(ts|tsx)$/,
-          loader: 'awesome-typescript-loader',
-        },
-        {
-          test: /\.(png|jpg|gif|svg|woff|ttf|eot)/,
-          loader: 'url-loader?limit=20480&name=static/[name].[ext]',
-        },
-        {
-          test: /\.scss$/,
-          exclude: /node_modules/,
-          use: [
-            ExtractTextPlugin.loader,
-            {
-              loader: 'css-loader',
-            },
-            {
-              loader: 'resolve-url-loader',
-            },
-            {
-              loader: 'sass-loader',
-            },
-          ],
-        },
-      ],
+      rules,
     },
     resolve: {
       extensions: ['.js', '.jsx'],


### PR DESCRIPTION
### Fixes https://github.com/ManageIQ/react-ui-components/issues/47
Storybook task is broken because of wrong webpack config. Looks like storybook for webpack 4 does not imports rules from master config so we need to reimport them by ourselves.

When doing so let's ignore node_modules, data, stories folders and vendor file for eslint.