### PR TITLE
Set eslint no typos to warning level

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
     "jsx-a11y/no-noninteractive-element-interactions": [1],
     "jsx-a11y/anchor-is-valid": [1],
     "no-unused-expressions": [1],
+    "react/no-typos": [1],
   },
   "settings" : {
     "import/extensions": ["js", "jsx"]


### PR DESCRIPTION
Set eslint no typos to warning level. Because if you define PropTypes constant in separate file, and use it in PropTypes definition in components it causes this error.

@karelhala 