### PR TITLE
[WIP ]Rbac user editing, and routing.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/index.js"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "connected-react-router": "^4.3.0",
     "final-form": "^4.7.3",
     "history": "^4.7.2",
+    "lodash": "^4.17.10",
     "patternfly-react": "^2.5.1",
     "prop-types": "^15.6.1",
     "react": "^16.4.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
+    "@khala/commit-analyzer-wildcard": "^1.0.4",
     "@storybook/addon-actions": "^4.0.0-alpha.0",
     "@storybook/addon-info": "^4.0.0-alpha.0",
     "@storybook/addon-links": "^4.0.0-alpha.0",
@@ -59,7 +60,6 @@
     "@storybook/addon-storysource": "^3.4.6",
     "@storybook/addons": "^4.0.0-alpha.0",
     "@storybook/react": "^4.0.0-alpha.0",
-    "@khala/commit-analyzer-wildcard": "^1.0.4",
     "autobind-decorator": "^2.1.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^7.2.3",
@@ -97,12 +97,12 @@
     "redux-mock-store": "^1.5.1",
     "resolve-url-loader": "^2.2.1",
     "sass-loader": "^7.0.2",
+    "semantic-release": "^15.5.0",
     "style-loader": "^0.21.0",
     "url-loader": "^1.0.1",
     "webpack": "^4.10.2",
     "webpack-cli": "^3.0.2",
-    "webpack-dev-server": "^3.1.4",
-    "semantic-release": "^15.5.0"
+    "webpack-dev-server": "^3.1.4"
   },
   "dependencies": {
     "connected-react-router": "^4.3.0",
@@ -119,7 +119,8 @@
     "react-select": "^1.2.1",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
-    "redux-mock-store": "^1.5.1"
+    "redux-mock-store": "^1.5.1",
+    "redux-thunk": "^2.3.0"
   },
   "release": {
     "analyzeCommits": "@khala/commit-analyzer-wildcard/analyzer",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,9 @@
     "semantic-release": "^15.5.0"
   },
   "dependencies": {
+    "connected-react-router": "^4.3.0",
     "final-form": "^4.7.3",
+    "history": "^4.7.2",
     "patternfly-react": "^2.5.1",
     "prop-types": "^15.6.1",
     "react": "^16.4.0",
@@ -113,9 +115,11 @@
     "react-dom": "^16.4.0",
     "react-final-form": "^3.5.1",
     "react-redux": "^5.0.6",
+    "react-router-dom": "^4.3.1",
     "react-select": "^1.2.1",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
+<<<<<<< HEAD
     "redux-mock-store": "^1.5.1"
   },
   "release": {
@@ -130,5 +134,9 @@
         "message": "Release of new version: ${nextRelease.version} <no> [skip ci]"
       }
     ]
+=======
+    "redux-mock-store": "^1.5.1",
+    "redux-thunk": "^2.3.0"
+>>>>>>> Exposed react-router-dom on window.
   }
 }

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "react-select": "^1.2.1",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
-<<<<<<< HEAD
     "redux-mock-store": "^1.5.1"
   },
   "release": {
@@ -133,10 +132,8 @@
         ],
         "message": "Release of new version: ${nextRelease.version} <no> [skip ci]"
       }
-    ]
-=======
+    ],
     "redux-mock-store": "^1.5.1",
     "redux-thunk": "^2.3.0"
->>>>>>> Exposed react-router-dom on window.
   }
 }

--- a/src/amazon-security-form-group/stories/amazon-security-form-group.stories.jsx
+++ b/src/amazon-security-form-group/stories/amazon-security-form-group.stories.jsx
@@ -77,6 +77,6 @@ storiesOf('Amazon Security forms', module).add('Amazon Security form group', wit
     onSave={action('onSubmit')}
     onCancel={action('onCancel')}
     loadData={simulateRequest}
-    updateFormState={action('State update')}
+    updateFormState={values => console.log(values)}
   />
 )));

--- a/src/forms/finalFormComponent.jsx
+++ b/src/forms/finalFormComponent.jsx
@@ -45,6 +45,7 @@ const FinalFormComponent = ({
   placeholder,
   type,
   maxLength,
+  children,
   disabled,
   ...rest
 }) => {
@@ -77,6 +78,7 @@ const FinalFormComponent = ({
         {componentSelect(componentType, inputProps)}
         {invalid && <HelpBlock>{meta.error}</HelpBlock>}
       </Col>
+      {children}
     </FormGroup>
   );
 };
@@ -144,6 +146,10 @@ FinalFormComponent.propTypes = {
   labelKey: PropTypes.string,
   valueKey: PropTypes.string,
   maxLength: PropTypes.number,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
   disabled: PropTypes.bool,
 };
 

--- a/src/manageiq-validators/index.js
+++ b/src/manageiq-validators/index.js
@@ -1,1 +1,2 @@
 export * from './regexPatterns';
+export * from './manageIqPropTypes';

--- a/src/manageiq-validators/manageIqPropTypes.js
+++ b/src/manageiq-validators/manageIqPropTypes.js
@@ -1,0 +1,15 @@
+import { emailPattern } from './';
+
+export const emailPropType = ({
+  props,
+  propName,
+  componentName,
+  isRequired,
+}) => {
+  if (!props[propName] && !isRequired) {
+    return undefined;
+  }
+  return emailPattern.test(props[propName])
+    ? undefined
+    : new Error(`Invalid prop  ${propName} supplied to ${componentName} Validation failed. Expected email address.`);
+};

--- a/src/rbac-forms/formPasswordFragment.jsx
+++ b/src/rbac-forms/formPasswordFragment.jsx
@@ -24,6 +24,7 @@ export default class PasswordFragment extends PureComponent {
         <Fragment>
           <Col xs={12}>
             <Field
+              id="password"
               name="password"
               type="password"
               validate={required({ msg: __('Required') })}
@@ -34,6 +35,7 @@ export default class PasswordFragment extends PureComponent {
                 isEditing &&
                 <Col md={2}>
                   <button
+                    id="password-change-disabler"
                     tabIndex="-1"
                     type="button"
                     className="button-link"
@@ -50,6 +52,7 @@ export default class PasswordFragment extends PureComponent {
           </Col>
           <Col xs={12}>
             <Field
+              id="password-verify"
               name="verify"
               type="password"
               validate={required({ msg: __('Required') })}
@@ -71,7 +74,7 @@ export default class PasswordFragment extends PureComponent {
           placeholder="●●●●●●●●"
         >
           <Col md={2}>
-            <button tabIndex="-1" type="button" className="button-link" onClick={this.handleChangeEdit}>
+            <button id="password-change-enabler" tabIndex="-1" type="button" className="button-link" onClick={this.handleChangeEdit}>
               {__('Change stored password')}
             </button>
           </Col>

--- a/src/rbac-forms/formPasswordFragment.jsx
+++ b/src/rbac-forms/formPasswordFragment.jsx
@@ -1,0 +1,91 @@
+import React, { PureComponent, Fragment } from 'react';
+import { Field } from 'react-final-form';
+import { required } from 'redux-form-validators';
+import { Col } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { FinalFormField } from '../forms';
+import { __ } from '../global-functions';
+
+export default class PasswordFragment extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      editEnabled: false,
+    };
+  }
+
+  handleChangeEdit = () => this.setState(prevState => ({ editEnabled: !prevState.editEnabled }));
+
+  render() {
+    const { isEditing, changeValue } = this.props;
+    const { editEnabled } = this.state;
+    if (!isEditing || editEnabled) {
+      return (
+        <Fragment>
+          <Col xs={12}>
+            <Field
+              name="password"
+              type="password"
+              validate={required({ msg: __('Required') })}
+              component={FinalFormField}
+              label={__('Password')}
+            >
+              {
+                isEditing &&
+                <Col md={2}>
+                  <button
+                    tabIndex="-1"
+                    type="button"
+                    className="button-link"
+                    onClick={() => {
+                      changeValue('password', null);
+                      this.handleChangeEdit();
+                    }}
+                  >
+                    {__('Cancel password change')}
+                  </button>
+                </Col>
+              }
+            </Field>
+          </Col>
+          <Col xs={12}>
+            <Field
+              name="verify"
+              type="password"
+              validate={required({ msg: __('Required') })}
+              component={FinalFormField}
+              label={__('Confirm password')}
+            />
+          </Col>
+        </Fragment>
+      );
+    }
+    return (
+      <Col xs={12}>
+        <Field
+          name="password"
+          type="password"
+          component={FinalFormField}
+          label={__('Password')}
+          disabled
+          placeholder="●●●●●●●●"
+        >
+          <Col md={2}>
+            <button tabIndex="-1" type="button" className="button-link" onClick={this.handleChangeEdit}>
+              {__('Change stored password')}
+            </button>
+          </Col>
+        </Field>
+      </Col>
+    );
+  }
+}
+
+PasswordFragment.propTypes = {
+  isEditing: PropTypes.bool,
+  changeValue: PropTypes.func.isRequired,
+};
+
+PasswordFragment.defaultProps = {
+  isEditing: false,
+};

--- a/src/rbac-forms/formPasswordFragment.jsx
+++ b/src/rbac-forms/formPasswordFragment.jsx
@@ -41,6 +41,7 @@ export default class PasswordFragment extends PureComponent {
                     className="button-link"
                     onClick={() => {
                       changeValue('password', null);
+                      changeValue('verify', null);
                       this.handleChangeEdit();
                     }}
                   >

--- a/src/rbac-forms/index.js
+++ b/src/rbac-forms/index.js
@@ -4,5 +4,6 @@ export { default as usersReducer } from './rbacUserManagementModule/redux/reduce
 export { default as UserAdd } from './rbacUserManagementModule/pages/userAdd';
 export { default as UserEdit } from './rbacUserManagementModule/pages/userEdit';
 export { default as UserPreview } from './rbacUserManagementModule/pages/userPreview';
-export { default as UserUsersList } from './rbacUserManagementModule/pages/usersList';
+export { default as RbacUsersList } from './rbacUserManagementModule/pages/usersList';
 export * from './rbacUserManagementModule/redux/actions/actions';
+export * from './rbacUserManagementModule/redux/actions/actionTypes';

--- a/src/rbac-forms/index.js
+++ b/src/rbac-forms/index.js
@@ -5,5 +5,6 @@ export { default as UserAdd } from './rbacUserManagementModule/pages/userAdd';
 export { default as UserEdit } from './rbacUserManagementModule/pages/userEdit';
 export { default as UserPreview } from './rbacUserManagementModule/pages/userPreview';
 export { default as RbacUsersList } from './rbacUserManagementModule/pages/usersList';
+export { default as AssignCompanyTags } from './rbacUserManagementModule/pages/assignCompanyTags';
 export * from './rbacUserManagementModule/redux/actions/actions';
 export * from './rbacUserManagementModule/redux/actions/actionTypes';

--- a/src/rbac-forms/index.js
+++ b/src/rbac-forms/index.js
@@ -1,2 +1,8 @@
 export { default as RbacUserForm } from './rbacUserForm';
 export { default as RbacUserPreview } from './rbacUserPreview';
+export { default as usersReducer } from './rbacUserManagementModule/redux/reducers/usersReducer';
+export { default as UserAdd } from './rbacUserManagementModule/pages/userAdd';
+export { default as UserEdit } from './rbacUserManagementModule/pages/userEdit';
+export { default as UserPreview } from './rbacUserManagementModule/pages/userPreview';
+export { default as UserUsersList } from './rbacUserManagementModule/pages/usersList';
+export * from './rbacUserManagementModule/redux/actions/actions';

--- a/src/rbac-forms/rbacUserForm.jsx
+++ b/src/rbac-forms/rbacUserForm.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import { Form, Field } from 'react-final-form';
 import PropTypes from 'prop-types';
 import { required, email } from 'redux-form-validators';
@@ -6,21 +6,34 @@ import { Form as PfForm, Col, Row, Grid, Button, ButtonGroup } from 'patternfly-
 
 import { FinalFormField, FinalFormSelect, composeValidators } from '../forms';
 import { __ } from '../global-functions';
+import { emailPropType } from '../manageiq-validators';
+import './styles.scss';
 
-const mapMultiSelectValues = (values, keyName) => Array.from(values, item => item[keyName]);
 const validateEmpty = values => (values.length === 0 ? __('A User must be assigned to a Group') : undefined);
 
-const RbacUserForm = ({ onSave, groups, onCancel }) => (
+const RbacUserForm = ({
+  onSave,
+  groups,
+  onCancel,
+  initialValues,
+  editDisabled,
+}) => (
   <Form
-    onSubmit={values => onSave({ ...values, chosen_group: mapMultiSelectValues(values.chosen_group, 'value') })}
+    onSubmit={values => onSave({ ...values, chosen_group: values.chosen_group.length > 0 ? values.chosen_group : null })}
     validate={(values) => {
       const errors = {};
-      if (values.password !== values.verify) {
+      if (values.password && values.password !== values.verify) {
         errors.verify = __('Password/Verify Password do not match');
       }
       return errors;
     }}
-    render={({ invalid, handleSubmit }) => (
+    initialValues={initialValues}
+    render={({
+      invalid,
+      pristine,
+      handleSubmit,
+      form: { change, reset },
+    }) => (
       <PfForm horizontal>
         <Grid>
           <Row>
@@ -30,6 +43,7 @@ const RbacUserForm = ({ onSave, groups, onCancel }) => (
                 validate={required({ msg: __('Required') })}
                 component={FinalFormField}
                 label={__('Full Name')}
+                disabled={initialValues && editDisabled}
               />
             </Col>
             <Col xs={12}>
@@ -38,26 +52,10 @@ const RbacUserForm = ({ onSave, groups, onCancel }) => (
                 validate={required({ msg: __('Required') })}
                 component={FinalFormField}
                 label={__('Username')}
+                disabled={initialValues && editDisabled}
               />
             </Col>
-            <Col xs={12}>
-              <Field
-                name="password"
-                type="password"
-                validate={required({ msg: __('Required') })}
-                component={FinalFormField}
-                label={__('Password')}
-              />
-            </Col>
-            <Col xs={12}>
-              <Field
-                name="verify"
-                type="password"
-                validate={required({ msg: __('Required') })}
-                component={FinalFormField}
-                label={__('Confirm password')}
-              />
-            </Col>
+            <PasswordFragment changeValue={change} isEditing={!!initialValues} />
             <Col xs={12}>
               <Field
                 name="email"
@@ -85,7 +83,16 @@ const RbacUserForm = ({ onSave, groups, onCancel }) => (
           <Row>
             <Col xs={10}>
               <ButtonGroup className="pull-right">
-                <Button id="user-submit" bsStyle="primary" disabled={invalid} type="button" onClick={handleSubmit}>{__('Add')}</Button>
+                <Button
+                  id="user-submit"
+                  bsStyle="primary"
+                  disabled={pristine || invalid}
+                  type="button"
+                  onClick={handleSubmit}
+                >
+                  {initialValues ? __('Save') : __('Add')}
+                </Button>
+                {initialValues && <Button disabled={pristine} onClick={reset} type="button">{__('Reset')}</Button>}
                 <Button onClick={onCancel}>{__('Cancel')}</Button>
               </ButtonGroup>
             </Col>
@@ -96,6 +103,90 @@ const RbacUserForm = ({ onSave, groups, onCancel }) => (
   />
 );
 
+class PasswordFragment extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      editEnabled: false,
+    };
+  }
+
+  handleChangeEdit = () => this.setState(prevState => ({ editEnabled: !prevState.editEnabled }));
+
+  render() {
+    const { isEditing, changeValue } = this.props;
+    const { editEnabled } = this.state;
+    if (!isEditing || editEnabled) {
+      return (
+        <Fragment>
+          <Col xs={12}>
+            <Field
+              name="password"
+              type="password"
+              validate={required({ msg: __('Required') })}
+              component={FinalFormField}
+              label={__('Password')}
+            >
+              {
+                isEditing &&
+                <Col md={2}>
+                  <button
+                    tabIndex="-1"
+                    type="button"
+                    className="button-link"
+                    onClick={() => {
+                      changeValue('password', null);
+                      this.handleChangeEdit();
+                    }}
+                  >
+                    {__('Cancel password change')}
+                  </button>
+                </Col>
+              }
+            </Field>
+          </Col>
+          <Col xs={12}>
+            <Field
+              name="verify"
+              type="password"
+              validate={required({ msg: __('Required') })}
+              component={FinalFormField}
+              label={__('Confirm password')}
+            />
+          </Col>
+        </Fragment>
+      );
+    }
+    return (
+      <Col xs={12}>
+        <Field
+          name="password"
+          type="password"
+          component={FinalFormField}
+          label={__('Password')}
+          disabled
+          placeholder="●●●●●●●●"
+        >
+          <Col md={2}>
+            <button tabIndex="-1" type="button" className="button-link" onClick={this.handleChangeEdit}>
+              {__('Change stored password')}
+            </button>
+          </Col>
+        </Field>
+      </Col>
+    );
+  }
+}
+
+PasswordFragment.propTypes = {
+  isEditing: PropTypes.bool,
+  changeValue: PropTypes.func.isRequired,
+};
+
+PasswordFragment.defaultProps = {
+  isEditing: false,
+};
+
 RbacUserForm.propTypes = {
   onSave: PropTypes.func.isRequired,
   groups: PropTypes.arrayOf(PropTypes.shape({
@@ -103,6 +194,22 @@ RbacUserForm.propTypes = {
     value: PropTypes.number.isRequired,
   })),
   onCancel: PropTypes.func.isRequired,
+  initialValues: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    userid: PropTypes.string.isRequired,
+    chosen_group: PropTypes.arrayOf(PropTypes.number),
+    email: (props, propsName, componentName) => emailPropType({
+      props,
+      propsName,
+      componentName,
+      isRequired: false,
+    }),
+  }),
+  editDisabled: PropTypes.bool,
+};
+
+RbacUserForm.defaultProps = {
+  editDisabled: false,
 };
 
 export default RbacUserForm;

--- a/src/rbac-forms/rbacUserForm.jsx
+++ b/src/rbac-forms/rbacUserForm.jsx
@@ -18,6 +18,7 @@ const RbacUserForm = ({
   onCancel,
   initialValues,
   editDisabled,
+  newRecord,
 }) => (
   <Form
     onSubmit={values => onSave({ ...values, groups: values.groups.length > 0 ? values.groups : null })}
@@ -44,7 +45,7 @@ const RbacUserForm = ({
                 validate={required({ msg: __('Required') })}
                 component={FinalFormField}
                 label={__('Full Name')}
-                disabled={initialValues && editDisabled}
+                disabled={!newRecord && editDisabled}
               />
             </Col>
             <Col xs={12}>
@@ -53,10 +54,10 @@ const RbacUserForm = ({
                 validate={required({ msg: __('Required') })}
                 component={FinalFormField}
                 label={__('Username')}
-                disabled={initialValues && editDisabled}
+                disabled={!newRecord && editDisabled}
               />
             </Col>
-            <PasswordFragment changeValue={change} isEditing={!!initialValues} />
+            <PasswordFragment changeValue={change} isEditing={!newRecord} />
             <Col xs={12}>
               <Field
                 name="email"
@@ -92,9 +93,9 @@ const RbacUserForm = ({
                   type="button"
                   onClick={handleSubmit}
                 >
-                  {initialValues ? __('Save') : __('Add')}
+                  {newRecord ? __('Add') : __('Save')}
                 </Button>
-                {initialValues && <Button disabled={pristine} onClick={reset} type="button">{__('Reset')}</Button>}
+                {!newRecord && <Button disabled={pristine} onClick={reset} type="button">{__('Reset')}</Button>}
                 <Button onClick={onCancel}>{__('Cancel')}</Button>
               </ButtonGroup>
             </Col>
@@ -113,8 +114,8 @@ RbacUserForm.propTypes = {
   })),
   onCancel: PropTypes.func.isRequired,
   initialValues: PropTypes.shape({
-    name: PropTypes.string.isRequired,
-    userid: PropTypes.string.isRequired,
+    name: PropTypes.string,
+    userid: PropTypes.string,
     chosen_group: PropTypes.arrayOf(PropTypes.string),
     email: (props, propsName, componentName) => emailPropType({
       props,
@@ -124,10 +125,12 @@ RbacUserForm.propTypes = {
     }),
   }),
   editDisabled: PropTypes.bool,
+  newRecord: PropTypes.bool,
 };
 
 RbacUserForm.defaultProps = {
   editDisabled: false,
+  newRecord: false,
 };
 
 export default RbacUserForm;

--- a/src/rbac-forms/rbacUserForm.jsx
+++ b/src/rbac-forms/rbacUserForm.jsx
@@ -1,10 +1,11 @@
-import React, { Fragment, PureComponent } from 'react';
+import React from 'react';
 import { Form, Field } from 'react-final-form';
 import PropTypes from 'prop-types';
 import { required, email } from 'redux-form-validators';
 import { Form as PfForm, Col, Row, Grid, Button, ButtonGroup } from 'patternfly-react';
 
 import { FinalFormField, FinalFormSelect, composeValidators } from '../forms';
+import PasswordFragment from './formPasswordFragment';
 import { __ } from '../global-functions';
 import { emailPropType } from '../manageiq-validators';
 import './styles.scss';
@@ -102,90 +103,6 @@ const RbacUserForm = ({
     )}
   />
 );
-
-class PasswordFragment extends PureComponent {
-  constructor(props) {
-    super(props);
-    this.state = {
-      editEnabled: false,
-    };
-  }
-
-  handleChangeEdit = () => this.setState(prevState => ({ editEnabled: !prevState.editEnabled }));
-
-  render() {
-    const { isEditing, changeValue } = this.props;
-    const { editEnabled } = this.state;
-    if (!isEditing || editEnabled) {
-      return (
-        <Fragment>
-          <Col xs={12}>
-            <Field
-              name="password"
-              type="password"
-              validate={required({ msg: __('Required') })}
-              component={FinalFormField}
-              label={__('Password')}
-            >
-              {
-                isEditing &&
-                <Col md={2}>
-                  <button
-                    tabIndex="-1"
-                    type="button"
-                    className="button-link"
-                    onClick={() => {
-                      changeValue('password', null);
-                      this.handleChangeEdit();
-                    }}
-                  >
-                    {__('Cancel password change')}
-                  </button>
-                </Col>
-              }
-            </Field>
-          </Col>
-          <Col xs={12}>
-            <Field
-              name="verify"
-              type="password"
-              validate={required({ msg: __('Required') })}
-              component={FinalFormField}
-              label={__('Confirm password')}
-            />
-          </Col>
-        </Fragment>
-      );
-    }
-    return (
-      <Col xs={12}>
-        <Field
-          name="password"
-          type="password"
-          component={FinalFormField}
-          label={__('Password')}
-          disabled
-          placeholder="●●●●●●●●"
-        >
-          <Col md={2}>
-            <button tabIndex="-1" type="button" className="button-link" onClick={this.handleChangeEdit}>
-              {__('Change stored password')}
-            </button>
-          </Col>
-        </Field>
-      </Col>
-    );
-  }
-}
-
-PasswordFragment.propTypes = {
-  isEditing: PropTypes.bool,
-  changeValue: PropTypes.func.isRequired,
-};
-
-PasswordFragment.defaultProps = {
-  isEditing: false,
-};
 
 RbacUserForm.propTypes = {
   onSave: PropTypes.func.isRequired,

--- a/src/rbac-forms/rbacUserForm.jsx
+++ b/src/rbac-forms/rbacUserForm.jsx
@@ -20,7 +20,7 @@ const RbacUserForm = ({
   editDisabled,
 }) => (
   <Form
-    onSubmit={values => onSave({ ...values, chosen_group: values.chosen_group.length > 0 ? values.chosen_group : null })}
+    onSubmit={values => onSave({ ...values, groups: values.groups.length > 0 ? values.groups : null })}
     validate={(values) => {
       const errors = {};
       if (values.password && values.password !== values.verify) {
@@ -71,13 +71,14 @@ const RbacUserForm = ({
             </Col>
             <Col xs={12}>
               <Field
-                name="chosen_group"
+                name="groups"
                 validate={composeValidators(required({ msg: __('A User must be assigned to a Group') }), validateEmpty)}
                 component={FinalFormSelect}
                 label={__('Available Groups')}
                 options={groups}
                 placeholder={__('Choose one or more Groups')}
                 multi
+                searchable
               />
             </Col>
           </Row>
@@ -108,13 +109,13 @@ RbacUserForm.propTypes = {
   onSave: PropTypes.func.isRequired,
   groups: PropTypes.arrayOf(PropTypes.shape({
     label: PropTypes.string.isRequired,
-    value: PropTypes.number.isRequired,
+    value: PropTypes.string.isRequired,
   })),
   onCancel: PropTypes.func.isRequired,
   initialValues: PropTypes.shape({
     name: PropTypes.string.isRequired,
     userid: PropTypes.string.isRequired,
-    chosen_group: PropTypes.arrayOf(PropTypes.number),
+    chosen_group: PropTypes.arrayOf(PropTypes.string),
     email: (props, propsName, componentName) => emailPropType({
       props,
       propsName,

--- a/src/rbac-forms/rbacUserManagementModule/index.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/index.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import { Provider, connect } from 'react-redux';
 import { Route, Switch } from 'react-router-dom';
 import { ConnectedRouter, goBack } from 'connected-react-router';
-import { Button, Grid, Row, Col, ListGroup, ListGroupItem } from 'patternfly-react';
+import { Button, Grid, Row, Col, ListGroup, ListGroupItem, Spinner } from 'patternfly-react';
 import PropTypes from 'prop-types';
 import { history, store } from './redux/reducers/';
 import { navigate, requestUsers, deleteUser } from './redux/actions/actions';
@@ -86,8 +86,8 @@ class App extends PureComponent {
   renderuserEdit = props => <UserEdit onSave={this.mockUserSave} {...props} />;
 
   render() {
-    if (!this.props.isLoaded) {
-      return <div>Loading</div>;
+    if (this.props.isFetching || !this.props.isLoaded) {
+      return <div><Spinner loading size="lg" /></div>;
     }
     return (
       <Grid fluid>
@@ -115,11 +115,12 @@ class App extends PureComponent {
 }
 
 App.propTypes = {
+  isFetching: PropTypes.bool.isRequired,
   isLoaded: PropTypes.bool.isRequired,
   loadUsersData: PropTypes.func.isRequired,
 };
 
-const mapAppToProps = ({ usersReducer: { isLoaded } }) => ({ isLoaded });
+const mapAppToProps = ({ usersReducer: { isFetching, isLoaded } }) => ({ isFetching, isLoaded });
 const mapAppToDispatch = dispatch => ({
   loadUsersData: callBack => dispatch(requestUsers(callBack)),
 });
@@ -128,7 +129,7 @@ const WrappedApp = connect(mapAppToProps, mapAppToDispatch)(App);
 
 
 const wrapper = () => (
-  <Provider store={store}>
+  <Provider store={store} >
     <WrappedApp />
   </Provider>
 );

--- a/src/rbac-forms/rbacUserManagementModule/index.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/index.jsx
@@ -1,0 +1,136 @@
+import React, { PureComponent } from 'react';
+import { Provider, connect } from 'react-redux';
+import { Route, Switch } from 'react-router-dom';
+import { ConnectedRouter, goBack } from 'connected-react-router';
+import { Button, Grid, Row, Col, ListGroup, ListGroupItem } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { history, store } from './redux/reducers/';
+import { navigate, requestUsers, deleteUser } from './redux/actions/actions';
+import UsersList from './pages/usersList';
+import UserAdd from './pages/userAdd';
+import UserEdit from './pages/userEdit';
+import UserPreview from './pages/userPreview';
+import { data } from './redux/data';
+
+const Toolbar = ({
+  handleAdd,
+  handleEdit,
+  canEdit,
+  editUserId,
+  handleDelete,
+}) => (
+  <div style={{ marginBottom: 10 }}>
+    <Button onClick={handleAdd}>Add</Button>
+    <Button disabled={!canEdit} onClick={() => handleEdit(editUserId)}>Edit selected</Button>
+    <Button disabled={!canEdit} onClick={() => handleDelete(editUserId)}>Delete selected</Button>
+  </div>
+);
+
+Toolbar.propTypes = {
+  handleAdd: PropTypes.func.isRequired,
+  handleEdit: PropTypes.func.isRequired,
+  canEdit: PropTypes.bool.isRequired,
+  editUserId: PropTypes.number,
+  handleDelete: PropTypes.func.isRequired,
+};
+
+const mapToolbarProps = ({ usersReducer: { selectedUsers } }) => ({
+  canEdit: !!(selectedUsers && selectedUsers.length === 1),
+  editUserId: selectedUsers ? selectedUsers[0].id : undefined,
+});
+
+const mapToolbarDispatch = (dispatch, { deleteCallback }) => ({
+  handleAdd: () => dispatch(navigate('/add')),
+  handleEdit: userId => dispatch(navigate(`/edit/${userId}`)),
+  handleDelete: userId => dispatch(deleteUser(userId, deleteCallback)),
+});
+
+const ConnectedToolbar = connect(mapToolbarProps, mapToolbarDispatch)(Toolbar);
+
+
+const Tree = ({ users, onUserClick, back }) => (
+  <ListGroup>
+    {users.map(user => <ListGroupItem key={`user-${user.id}`} onClick={() => onUserClick(user.id)}>{user.name}</ListGroupItem>)}
+    <ListGroupItem onClick={back}>Back in history</ListGroupItem>
+  </ListGroup>
+);
+
+Tree.propTypes = {
+  users: PropTypes.array,
+  onUserClick: PropTypes.func,
+  back: PropTypes.func,
+};
+
+const mapTreeProps = ({ usersReducer: { rows } }) => ({
+  users: rows,
+});
+
+const mapTreeDispatch = dispatch => ({
+  onUserClick: userId => dispatch(navigate(`/preview/${userId}`)),
+  back: () => dispatch(goBack()),
+});
+
+const ConnectedTree = connect(mapTreeProps, mapTreeDispatch)(Tree);
+
+
+class App extends PureComponent {
+  componentDidMount() {
+    this.props.loadUsersData(this.mockUsersRequest);
+  }
+
+  mockUsersRequest = () => new Promise(resolve => setTimeout(() => resolve(data), 1500))
+  mockUserSave = () => this.mockUsersRequest();
+  mockUserDelete = () => this.mockUsersRequest()
+
+  renderUserAdd = props => <UserAdd onSave={this.mockUserSave} {...props} />;
+  renderuserEdit = props => <UserEdit onSave={this.mockUserSave} {...props} />;
+
+  render() {
+    if (!this.props.isLoaded) {
+      return <div>Loading</div>;
+    }
+    return (
+      <Grid fluid>
+        <Row>
+          <Col xs={2}>
+            <ConnectedTree />
+          </Col>
+          <Col xs={10}>
+            <ConnectedToolbar deleteCallback={this.mockUserDelete} />
+            <ConnectedRouter history={history}>
+              <div>
+                <Switch>
+                  <Route exact path="/" component={UsersList} />
+                  <Route path="/add" render={props => this.renderUserAdd(props)} />
+                  <Route path="/preview/:userId" component={UserPreview} />
+                  <Route path="/edit/:userId" render={props => this.renderuserEdit(props)} />
+                </Switch>
+              </div>
+            </ConnectedRouter>
+          </Col>
+        </Row>
+      </Grid>
+    );
+  }
+}
+
+App.propTypes = {
+  isLoaded: PropTypes.bool.isRequired,
+  loadUsersData: PropTypes.func.isRequired,
+};
+
+const mapAppToProps = ({ usersReducer: { isLoaded } }) => ({ isLoaded });
+const mapAppToDispatch = dispatch => ({
+  loadUsersData: callBack => dispatch(requestUsers(callBack)),
+});
+
+const WrappedApp = connect(mapAppToProps, mapAppToDispatch)(App);
+
+
+const wrapper = () => (
+  <Provider store={store}>
+    <WrappedApp />
+  </Provider>
+);
+
+export default wrapper;

--- a/src/rbac-forms/rbacUserManagementModule/pages/assignCompanyTags.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/assignCompanyTags.jsx
@@ -1,0 +1,237 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Select from 'react-select';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+import { Spinner, Button, Icon, Row, Col, Grid, ButtonGroup } from 'patternfly-react';
+import { __ } from '../../../global-functions';
+import { GenericPreviewTable } from '../../../table';
+
+class AssignCompanyTags extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      selectedCategory: null,
+      categoryEntries: {},
+      selectedEntries: {},
+      isLoaded: false,
+      initialAssignments: {},
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.users) {
+      const commonTags = this.intersectionWith((a, b) => (a.id === b.id), ...this.props.users.map(user => user.tags));
+      const selectedEntries = {};
+      commonTags.forEach((tag) => {
+        selectedEntries[tag.name.split('/')[2]] = { value: tag.id };
+      });
+      const finalEntries = {};
+      Object.keys(selectedEntries).forEach((categoryName) => {
+        finalEntries[this.props.categories.find(category => category.name === categoryName).value] = { ...selectedEntries[categoryName] };
+      });
+      if (Object.keys(finalEntries).length > 0) {
+        this.props.loadMultipleEntries(Object.keys(finalEntries))
+          .then((categoryEntries) => {
+            Object.keys(finalEntries).forEach((entryId) => {
+              finalEntries[entryId] = { ...categoryEntries[entryId].find(item => item.value === parseInt(finalEntries[entryId].value, 10)) };
+            });
+            this.setState({
+              categoryEntries,
+              isLoaded: true,
+              selectedEntries: finalEntries,
+              initialAssignments: finalEntries,
+            });
+          });
+      } else {
+        this.setState({ isLoaded: true }); // eslint-disable-line
+      }
+    } else {
+      this.setState({ isLoaded: true }); // eslint-disable-line
+    }
+  }
+
+  intersectionWith = (comp, first, ...others) => first.filter(a => others.every(arr => arr.some(b => comp(a, b))));
+
+  handleCategorySelect = ({ value }) => {
+    this.loadCategoryEntries(value);
+    this.setState({ selectedCategory: value });
+  };
+
+  handleEntrySelect = value =>
+    this.setState(prevState => ({ selectedEntries: { ...prevState.selectedEntries, [prevState.selectedCategory]: value } }));
+
+  handleRemoveEntry = categoryId => this.setState(({ selectedEntries }) => {
+    const entries = { ...selectedEntries };
+    delete entries[categoryId];
+    return { selectedEntries: { ...entries } };
+  });
+
+  loadCategoryEntries = (categoryId) => {
+    if (!this.state.categoryEntries[categoryId]) {
+      this.props.loadCategoryEntry(categoryId)
+        .then(entries => this.setState(prevState => ({
+          categoryEntries: { ...prevState.categoryEntries, [categoryId]: entries },
+        })));
+    }
+  }
+
+  canSave = () => JSON.stringify(this.state.initialAssignments) !== JSON.stringify(this.state.selectedEntries);
+  handleReset = () => this.setState(prevState => ({ selectedCategory: null, selectedEntries: prevState.initialAssignments }))
+
+  renderTableEmptyBody = () => (
+    <tr>
+      <td />
+      <td>{__('No My Company Tags are assigned')}</td>
+      <td />
+    </tr>
+  );
+
+  renderTableBody = (entries, categories, categoryEntries) => Object.keys(entries)
+    .map(category => (
+      <tr key={category}>
+        <td>
+          <Button onClick={() => this.handleRemoveEntry(category)}>
+            <Icon type="pf" name="close" />
+          </Button>
+        </td>
+        <td>{categories.find(item => item.value === category).label}</td>
+        <td>{categoryEntries[category].find(item => item.value === entries[category].value).label}</td>
+      </tr>
+    ));
+
+  render() {
+    const {
+      columns,
+      categories,
+      handleCancel,
+      handleSave,
+      users,
+    } = this.props;
+    const {
+      selectedCategory,
+      categoryEntries,
+      selectedEntries,
+      isLoaded,
+      initialAssignments,
+    } = this.state;
+    if (!users) return <Redirect to="/" />;
+    if (!isLoaded) return <Spinner loading />;
+    return (
+      <Grid>
+        <Row>
+          <Col xs={12}>
+
+            <h3>{__('Tag Assignment')}</h3>
+            <table className="table table-bordered" style={{ marginBottom: 0 }}>
+              <thead>
+                <tr>
+                  <th>
+                    {__('Select a customer tag to assign')}
+                  </th>
+                  <th>
+                    <Select
+                      className="final-form-select"
+                      optionClassName="final-form-select-option"
+                      options={categories}
+                      onChange={this.handleCategorySelect}
+                      searchable={false}
+                      clearable={false}
+                      value={selectedCategory}
+                    />
+                  </th>
+                  <th>
+                    <Select
+                      className="final-form-select"
+                      optionClassName="final-form-select-option"
+                      options={categoryEntries[selectedCategory]}
+                      onChange={this.handleEntrySelect}
+                      searchable={false}
+                      clearable={false}
+                      value={selectedEntries[selectedCategory]}
+                      disabled={!selectedCategory}
+                    />
+                  </th>
+                </tr>
+              </thead>
+            </table>
+            <table className="table table-striped table-bordered">
+              <thead>
+                <tr>
+                  <th className="table-view-pf-select" />
+                  <th>{__('Category')}</th>
+                  <th>{__('Assigned Value')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.keys(selectedEntries).length > 0 ?
+              this.renderTableBody(selectedEntries, categories, categoryEntries) : this.renderTableEmptyBody()}
+              </tbody>
+            </table>
+            <p>
+          * Only a single value can be assigned from these categories
+            </p>
+            <hr />
+            <h3>{__('EVM User Being Tagged')}</h3>
+            <GenericPreviewTable
+              showIcon
+              icon={{
+            type: 'pf',
+            name: 'user',
+          }}
+              rows={[...users.map(({ role, current_group, ...rest }) => ({ // eslint-disable-line camelcase
+            role: role.label,
+            current_group: current_group.label,
+            ...rest,
+          }))]}
+              columns={columns}
+              rowKey="id"
+              rowClick={() => {}}
+              rowSelect={() => {}}
+            />
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={12} style={{ marginTop: 10 }}>
+            <ButtonGroup className="pull-right">
+              <Button
+                id="user-submit"
+                bsStyle="primary"
+                disabled={!this.canSave()}
+                type="button"
+                onClick={() => handleSave(selectedEntries, initialAssignments, users)}
+              >
+                {__('Save')}
+              </Button>
+              <Button
+                disabled={!this.canSave()}
+                type="button"
+                onClick={this.handleReset}
+              >
+                {__('Reset')}
+              </Button>
+              <Button onClick={handleCancel}>{__('Cancel')}</Button>
+            </ButtonGroup>
+          </Col>
+        </Row>
+      </Grid>
+    );
+  }
+}
+
+AssignCompanyTags.propTypes = {
+  columns: PropTypes.array.isRequired,
+  categories: PropTypes.array.isRequired,
+  loadCategoryEntry: PropTypes.func.isRequired,
+  handleCancel: PropTypes.func.isRequired,
+  handleSave: PropTypes.func.isRequired,
+  users: PropTypes.array,
+  loadMultipleEntries: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ usersReducer: { selectedUsers, columns } }) => ({
+  users: selectedUsers,
+  columns,
+});
+
+export default connect(mapStateToProps)(AssignCompanyTags);

--- a/src/rbac-forms/rbacUserManagementModule/pages/helpers.js
+++ b/src/rbac-forms/rbacUserManagementModule/pages/helpers.js
@@ -1,0 +1,13 @@
+export const parseUserValues = ({
+  name,
+  userid,
+  groups, // eslint-disable-line
+  password,
+  email,
+}) => ({
+  name,
+  userid,
+  miq_groups: groups.map(item => ({ id: item })),
+  password,
+  email,
+});

--- a/src/rbac-forms/rbacUserManagementModule/pages/userAdd.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userAdd.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { goBack } from 'connected-react-router';
+import { RbacUserForm } from '../../';
+import { saveUser } from '../redux/actions/actions';
+
+const UserAdd = ({
+  groups,
+  onSave,
+  onCancel,
+}) => (
+  <RbacUserForm
+    groups={groups}
+    onSave={values => onSave(values)}
+    onCancel={onCancel}
+  />
+);
+
+UserAdd.propTypes = {
+  groups: PropTypes.array.isRequired,
+  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ usersReducer: { groups } }) => ({
+  groups,
+});
+
+const mapDispatchToProps = (dispatch, initialProps) => ({
+  onCancel: () => dispatch(goBack()),
+  onSave: values => dispatch(saveUser(values, initialProps.onSave)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(UserAdd);

--- a/src/rbac-forms/rbacUserManagementModule/pages/userAdd.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userAdd.jsx
@@ -2,15 +2,15 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { goBack } from 'connected-react-router';
+import { Redirect } from 'react-router-dom';
 import { Spinner } from 'patternfly-react';
 import { RbacUserForm } from '../../';
-import { saveUser, loadGroups } from '../redux/actions/actions';
 import { parseUserValues } from './helpers';
 
 class UserAdd extends PureComponent {
   componentDidMount() {
     if (!this.props.groups) {
-      this.props.loadGroups(this.props.getGroups);
+      this.props.loadGroups();
     }
   }
   render() {
@@ -18,15 +18,22 @@ class UserAdd extends PureComponent {
       groups,
       onSave,
       onCancel,
+      userCopy,
+      match: { params: { copy } },
     } = this.props;
     if (!groups || this.props.isFetching) {
       return <div><Spinner loading size="lg" /></div>;
+    }
+    if (copy && !userCopy) {
+      return <Redirect to="/add" />;
     }
     return (
       <RbacUserForm
         groups={[...groups]}
         onSave={values => onSave(parseUserValues(values))}
         onCancel={onCancel}
+        newRecord
+        initialValues={userCopy ? { ...userCopy, groups: userCopy.groups.map(group => group.groupId) } : {}}
       />
     );
   }
@@ -37,23 +44,28 @@ UserAdd.propTypes = {
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   loadGroups: PropTypes.func.isRequired,
-  getGroups: PropTypes.func.isRequired,
   isFetching: PropTypes.bool,
+  userCopy: PropTypes.object,
+  match: PropTypes.object,
 };
 
 UserAdd.defaultProps = {
   isFetching: false,
 };
 
-const mapStateToProps = ({ usersReducer: { groups, isFetching } }) => ({
+const mapStateToProps = ({ usersReducer: { groups, isFetching, selectedUsers } }, { match: { params: { copy } } }) => ({
   groups,
   isFetching,
+  userCopy: selectedUsers && copy ? {
+    name: selectedUsers[0].name,
+    email: selectedUsers[0].email,
+    groups: selectedUsers[0].groups,
+    miq_groups: selectedUsers[0].miq_groups,
+  } : undefined,
 });
 
-const mapDispatchToProps = (dispatch, initialProps) => ({
+const mapDispatchToProps = dispatch => ({
   onCancel: () => dispatch(goBack()),
-  onSave: values => dispatch(saveUser(values, initialProps.onSave, initialProps.loadUsers)),
-  loadGroups: callback => dispatch(loadGroups(callback)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserAdd);

--- a/src/rbac-forms/rbacUserManagementModule/pages/userAdd.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userAdd.jsx
@@ -1,35 +1,59 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { goBack } from 'connected-react-router';
+import { Spinner } from 'patternfly-react';
 import { RbacUserForm } from '../../';
-import { saveUser } from '../redux/actions/actions';
+import { saveUser, loadGroups } from '../redux/actions/actions';
+import { parseUserValues } from './helpers';
 
-const UserAdd = ({
-  groups,
-  onSave,
-  onCancel,
-}) => (
-  <RbacUserForm
-    groups={groups}
-    onSave={values => onSave(values)}
-    onCancel={onCancel}
-  />
-);
+class UserAdd extends PureComponent {
+  componentDidMount() {
+    if (!this.props.groups) {
+      this.props.loadGroups(this.props.getGroups);
+    }
+  }
+  render() {
+    const {
+      groups,
+      onSave,
+      onCancel,
+    } = this.props;
+    if (!groups || this.props.isFetching) {
+      return <div><Spinner loading size="lg" /></div>;
+    }
+    return (
+      <RbacUserForm
+        groups={[...groups]}
+        onSave={values => onSave(parseUserValues(values))}
+        onCancel={onCancel}
+      />
+    );
+  }
+}
 
 UserAdd.propTypes = {
-  groups: PropTypes.array.isRequired,
+  groups: PropTypes.array,
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  loadGroups: PropTypes.func.isRequired,
+  getGroups: PropTypes.func.isRequired,
+  isFetching: PropTypes.bool,
 };
 
-const mapStateToProps = ({ usersReducer: { groups } }) => ({
+UserAdd.defaultProps = {
+  isFetching: false,
+};
+
+const mapStateToProps = ({ usersReducer: { groups, isFetching } }) => ({
   groups,
+  isFetching,
 });
 
 const mapDispatchToProps = (dispatch, initialProps) => ({
   onCancel: () => dispatch(goBack()),
-  onSave: values => dispatch(saveUser(values, initialProps.onSave)),
+  onSave: values => dispatch(saveUser(values, initialProps.onSave, initialProps.loadUsers)),
+  loadGroups: callback => dispatch(loadGroups(callback)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserAdd);

--- a/src/rbac-forms/rbacUserManagementModule/pages/userEdit.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userEdit.jsx
@@ -1,40 +1,68 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { goBack } from 'connected-react-router';
+import { Spinner } from 'patternfly-react';
 import { RbacUserForm } from '../../';
-import { saveUser } from '../redux/actions/actions';
+import { saveUser, loadGroups } from '../redux/actions/actions';
+import { parseUserValues } from './helpers';
 
-const UserEdit = ({
-  user,
-  groups,
-  onSave,
-  onCancel,
-}) => (
-  <RbacUserForm
-    groups={groups}
-    onSave={values => onSave(values)}
-    onCancel={onCancel}
-    initialValues={user}
-    editDisabled={user.userid === 'admin'}
-  />
-);
+class UserEdit extends PureComponent {
+  componentDidMount() {
+    if (!this.props.groups) {
+      this.props.loadGroups(this.props.getGroups);
+    }
+  }
+
+  render() {
+    const {
+      user,
+      groups,
+      onSave,
+      onCancel,
+    } = this.props;
+
+    if (!groups || this.props.isFetching) {
+      return <div><Spinner loading size="lg" /></div>;
+    }
+
+    return (
+      <RbacUserForm
+        groups={groups}
+        onSave={values => onSave(parseUserValues(values))}
+        onCancel={onCancel}
+        initialValues={user}
+        editDisabled={user.userid === 'admin'}
+      />
+    );
+  }
+}
 
 UserEdit.propTypes = {
   user: PropTypes.object.isRequired,
-  groups: PropTypes.array.isRequired,
+  groups: PropTypes.array,
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
+  loadGroups: PropTypes.func.isRequired,
+  getGroups: PropTypes.func.isRequired,
+  isFetching: PropTypes.bool,
 };
 
-const mapStateToProps = ({ usersReducer: { rows, groups } }, { match: { params } }) => ({
-  user: rows.find(row => row.id === Number.parseInt(params.userId, 10)),
+UserEdit.defaultProps = {
+  isFetching: false,
+};
+
+
+const mapStateToProps = ({ usersReducer: { rows, groups, isFetching } }, { match: { params } }) => ({
+  user: rows.find(row => row.id === params.userId),
   groups,
+  isFetching,
 });
 
 const mapDispatchToProps = (dispatch, initialProps) => ({
   onCancel: () => dispatch(goBack()),
   onSave: values => dispatch(saveUser(values, initialProps.onSave)),
+  loadGroups: callback => dispatch(loadGroups(callback)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserEdit);

--- a/src/rbac-forms/rbacUserManagementModule/pages/userEdit.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userEdit.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { goBack } from 'connected-react-router';
+import { RbacUserForm } from '../../';
+import { saveUser } from '../redux/actions/actions';
+
+const UserEdit = ({
+  user,
+  groups,
+  onSave,
+  onCancel,
+}) => (
+  <RbacUserForm
+    groups={groups}
+    onSave={values => onSave(values)}
+    onCancel={onCancel}
+    initialValues={user}
+    editDisabled={user.userid === 'admin'}
+  />
+);
+
+UserEdit.propTypes = {
+  user: PropTypes.object.isRequired,
+  groups: PropTypes.array.isRequired,
+  onSave: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ usersReducer: { rows, groups } }, { match: { params } }) => ({
+  user: rows.find(row => row.id === Number.parseInt(params.userId, 10)),
+  groups,
+});
+
+const mapDispatchToProps = (dispatch, initialProps) => ({
+  onCancel: () => dispatch(goBack()),
+  onSave: values => dispatch(saveUser(values, initialProps.onSave)),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(UserEdit);

--- a/src/rbac-forms/rbacUserManagementModule/pages/userEdit.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userEdit.jsx
@@ -4,13 +4,12 @@ import PropTypes from 'prop-types';
 import { goBack } from 'connected-react-router';
 import { Spinner } from 'patternfly-react';
 import { RbacUserForm } from '../../';
-import { saveUser, loadGroups } from '../redux/actions/actions';
 import { parseUserValues } from './helpers';
 
 class UserEdit extends PureComponent {
   componentDidMount() {
     if (!this.props.groups) {
-      this.props.loadGroups(this.props.getGroups);
+      this.props.loadGroups();
     }
   }
 
@@ -29,9 +28,9 @@ class UserEdit extends PureComponent {
     return (
       <RbacUserForm
         groups={groups}
-        onSave={values => onSave(parseUserValues(values))}
+        onSave={values => onSave(parseUserValues(values), values.id)}
         onCancel={onCancel}
-        initialValues={user}
+        initialValues={{ ...user, groups: user.groups.map(group => group.groupId) }}
         editDisabled={user.userid === 'admin'}
       />
     );
@@ -44,7 +43,6 @@ UserEdit.propTypes = {
   onSave: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
   loadGroups: PropTypes.func.isRequired,
-  getGroups: PropTypes.func.isRequired,
   isFetching: PropTypes.bool,
 };
 
@@ -59,10 +57,8 @@ const mapStateToProps = ({ usersReducer: { rows, groups, isFetching } }, { match
   isFetching,
 });
 
-const mapDispatchToProps = (dispatch, initialProps) => ({
+const mapDispatchToProps = dispatch => ({
   onCancel: () => dispatch(goBack()),
-  onSave: values => dispatch(saveUser(values, initialProps.onSave)),
-  loadGroups: callback => dispatch(loadGroups(callback)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserEdit);

--- a/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
@@ -11,7 +11,7 @@ UserPreview.propTypes = {
 };
 
 const mapStateToProps = ({ usersReducer: { rows } }, { match: { params } }) => ({
-  user: rows.find(user => user.id === Number.parseInt(params.userId, 10)),
+  user: rows.find(user => user.id === params.userId),
 });
 
 export default connect(mapStateToProps)(UserPreview);

--- a/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
@@ -1,13 +1,29 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { RbacUserPreview } from '../../';
 
+class UserPreview extends Component {
+  componentDidMount() {
+    this.props.selectUser(this.props.user);
+  }
 
-const UserPreview = ({ user }) => <RbacUserPreview user={user} />;
+  componentDidUpdate(prevProps) {
+    const { user, selectUser } = this.props;
+    if (prevProps.user.id !== user.id) {
+      selectUser(this.props.user);
+    }
+  }
+
+  render() {
+    const { user } = this.props;
+    return <RbacUserPreview user={user} />;
+  }
+}
 
 UserPreview.propTypes = {
   user: PropTypes.object.isRequired,
+  selectUser: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ({ usersReducer: { rows } }, { match: { params } }) => ({

--- a/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
@@ -1,29 +1,53 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { RbacUserPreview } from '../../';
+import RbacUserTagsList from '../../rbacUserTagsList';
 
 class UserPreview extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      tags: [],
+      tenant: '',
+    };
+  }
+
   componentDidMount() {
-    this.props.selectUser(this.props.user);
+    const { user, selectUser } = this.props;
+    selectUser(user);
+    this.fetchTags(user.id);
   }
 
   componentDidUpdate(prevProps) {
     const { user, selectUser } = this.props;
     if (prevProps.user.id !== user.id) {
       selectUser(this.props.user);
+      this.fetchTags(user.id);
     }
   }
 
+  fetchTags = userId => this.props.getUserTags(userId)
+    .then(({ tags, tenant }) => ({ tags: [...tags.sort((a, b) => a.name < b.name)], tenant }))
+    .then(({ tags, tenant }) => this.setState({ tags, tenant }));
+
   render() {
     const { user } = this.props;
-    return <RbacUserPreview user={user} />;
+    const { tags, tenant } = this.state;
+    return (
+      <Fragment>
+        <RbacUserPreview user={user} />
+        <hr />
+        <RbacUserTagsList tags={tags} tenant={tenant} />
+      </Fragment>
+    );
   }
 }
 
 UserPreview.propTypes = {
   user: PropTypes.object.isRequired,
   selectUser: PropTypes.func.isRequired,
+  getUserTags: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ({ usersReducer: { rows } }, { match: { params } }) => ({

--- a/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/userPreview.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { RbacUserPreview } from '../../';
+
+
+const UserPreview = ({ user }) => <RbacUserPreview user={user} />;
+
+UserPreview.propTypes = {
+  user: PropTypes.object.isRequired,
+};
+
+const mapStateToProps = ({ usersReducer: { rows } }, { match: { params } }) => ({
+  user: rows.find(user => user.id === Number.parseInt(params.userId, 10)),
+});
+
+export default connect(mapStateToProps)(UserPreview);

--- a/src/rbac-forms/rbacUserManagementModule/pages/usersList.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/usersList.jsx
@@ -1,40 +1,42 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
 import { GenericPreviewTable } from '../../../table';
-import { navigate, selectUsers } from '../redux/actions/actions';
+import { __ } from '../../../global-functions';
 
 const UsersList = ({
   rows,
   columns,
-  routerNavigate,
-  storeSelectUsers,
+  handleSelectUser,
+  handleRowClick,
 }) => (
-  <GenericPreviewTable
-    rowClick={row => routerNavigate(`/users/preview/${row.id}`)}
-    rowSelect={users => storeSelectUsers(users.length > 0 ? users : null)}
-    showIcon
-    showSelect
-    icon={{
-      type: 'pf',
-      name: 'user',
-    }}
-    rows={[...rows.map(({ role, current_group, ...rest }) => ({ // eslint-disable-line camelcase
-      role: role.label,
-      current_group: current_group.label,
-      ...rest,
-    }))]}
-    columns={columns}
-    rowKey="id"
-  />
+  <Fragment>
+    <h1>{__('Access Control EVM Users')}</h1>
+    <GenericPreviewTable
+      rowClick={row => handleRowClick(row)}
+      rowSelect={(users, row) => handleSelectUser(users.length > 0 ? users : undefined, row)}
+      showIcon
+      showSelect
+      icon={{
+        type: 'pf',
+        name: 'user',
+      }}
+      rows={[...rows.map(({ role, current_group, ...rest }) => ({ // eslint-disable-line camelcase
+        role: role.label,
+        current_group: current_group.label,
+        ...rest,
+      }))]}
+      columns={columns}
+      rowKey="id"
+    />
+  </Fragment>
 );
 
 UsersList.propTypes = {
   rows: PropTypes.array.isRequired,
   columns: PropTypes.array.isRequired,
-  routerNavigate: PropTypes.func.isRequired,
-  storeSelectUsers: PropTypes.func.isRequired,
+  handleSelectUser: PropTypes.func.isRequired,
+  handleRowClick: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = ({ usersReducer: { rows, columns } }) => ({
@@ -42,9 +44,4 @@ const mapStateToProps = ({ usersReducer: { rows, columns } }) => ({
   columns,
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({
-  routerNavigate: navigate,
-  storeSelectUsers: selectUsers,
-}, dispatch);
-
-export default connect(mapStateToProps, mapDispatchToProps)(UsersList);
+export default connect(mapStateToProps)(UsersList);

--- a/src/rbac-forms/rbacUserManagementModule/pages/usersList.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/usersList.jsx
@@ -12,7 +12,7 @@ const UsersList = ({
   storeSelectUsers,
 }) => (
   <GenericPreviewTable
-    rowClick={row => routerNavigate(`/preview/${row.id}`)}
+    rowClick={row => routerNavigate(`/users/preview/${row.id}`)}
     rowSelect={users => storeSelectUsers(users.length > 0 ? users : null)}
     showIcon
     showSelect
@@ -20,11 +20,11 @@ const UsersList = ({
       type: 'pf',
       name: 'user',
     }}
-    rows={rows.map(({ role, current_group, ...rest }) => ({ // eslint-disable-line camelcase
+    rows={[...rows.map(({ role, current_group, ...rest }) => ({ // eslint-disable-line camelcase
       role: role.label,
       current_group: current_group.label,
       ...rest,
-    }))}
+    }))]}
     columns={columns}
     rowKey="id"
   />

--- a/src/rbac-forms/rbacUserManagementModule/pages/usersList.jsx
+++ b/src/rbac-forms/rbacUserManagementModule/pages/usersList.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { GenericPreviewTable } from '../../../table';
+import { navigate, selectUsers } from '../redux/actions/actions';
+
+const UsersList = ({
+  rows,
+  columns,
+  routerNavigate,
+  storeSelectUsers,
+}) => (
+  <GenericPreviewTable
+    rowClick={row => routerNavigate(`/preview/${row.id}`)}
+    rowSelect={users => storeSelectUsers(users.length > 0 ? users : null)}
+    showIcon
+    showSelect
+    icon={{
+      type: 'pf',
+      name: 'user',
+    }}
+    rows={rows.map(({ role, current_group, ...rest }) => ({ // eslint-disable-line camelcase
+      role: role.label,
+      current_group: current_group.label,
+      ...rest,
+    }))}
+    columns={columns}
+    rowKey="id"
+  />
+);
+
+UsersList.propTypes = {
+  rows: PropTypes.array.isRequired,
+  columns: PropTypes.array.isRequired,
+  routerNavigate: PropTypes.func.isRequired,
+  storeSelectUsers: PropTypes.func.isRequired,
+};
+
+const mapStateToProps = ({ usersReducer: { rows, columns } }) => ({
+  rows,
+  columns,
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators({
+  routerNavigate: navigate,
+  storeSelectUsers: selectUsers,
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(UsersList);

--- a/src/rbac-forms/rbacUserManagementModule/redux/actions/actionTypes.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/actions/actionTypes.js
@@ -1,0 +1,7 @@
+export const LOAD_DATA = '[api] Load users data';
+export const SELECT_USERS = '[command] Select users from list';
+export const SAVE_USER = '[api] Save user';
+export const FETCH_DATA = '[api] Fetch data';
+export const FETCH_SUCESFULL = '[message] Fetch sucesfull';
+export const REQUEST_FAILED = '[message] Request failes';
+export const DELETE_USER = '[message] Delete user';

--- a/src/rbac-forms/rbacUserManagementModule/redux/actions/actionTypes.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/actions/actionTypes.js
@@ -5,3 +5,6 @@ export const FETCH_DATA = '[api] Fetch data';
 export const FETCH_SUCESFULL = '[message] Fetch sucesfull';
 export const REQUEST_FAILED = '[message] Request failes';
 export const DELETE_USER = '[message] Delete user';
+export const LOAD_GROUPS = '[message] Load user groups';
+export const STORE_GROUPS = '[command] Store user groups';
+export const EDIT_USER = '[api] Edit user';

--- a/src/rbac-forms/rbacUserManagementModule/redux/actions/actions.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/actions/actions.js
@@ -35,7 +35,12 @@ const columns = [{
   label: 'Last Logoff',
 }];
 
-export const navigate = where => dispatch => dispatch(push(where));
+export const navigate = where => (dispatch, getState) => {
+  const { pathname } = getState().router.location;
+  if (pathname !== where) {
+    dispatch(push(where));
+  }
+};
 
 export const loadUsersData = data => ({
   type: LOAD_DATA,
@@ -89,25 +94,28 @@ export const requestUsers = callBack => (dispatch) => {
     .then(() => dispatch(fetchSucesfull()));
 };
 
-export const saveUser = (user, callBackSave, callBackFind) => (dispatch) => {
+export const saveUser = (user, callBackSave, callBackFind, callBackUpdateTree) => (dispatch) => {
   dispatch(fetchData(SAVE_USER));
   return callBackSave(user)
     .then(() => dispatch(requestUsers(callBackFind)))
+    .then(() => dispatch(callBackUpdateTree))
     .then(() => dispatch(navigate('/')))
     .catch(() => dispatch(fetchFailed));
 };
 
-export const deleteUser = (userId, callBack, callBackFind) => (dispatch) => {
+export const deleteUser = (userId, callBack, callBackFind, callBackUpdateTree) => (dispatch) => {
   dispatch(fetchData(DELETE_USER));
   return callBack(userId)
     .then(() => dispatch(requestUsers(callBackFind)))
+    .then(() => dispatch(callBackUpdateTree))
     .catch(() => dispatch(fetchFailed));
 };
 
-export const editUser = (user, callBackEdit, callBackFind) => (dispatch) => {
+export const editUser = (user, userId, callBackEdit, callBackFind, callBackUpdateTree) => (dispatch) => {
   dispatch(fetchData(EDIT_USER));
-  return callBackEdit(user)
+  return callBackEdit(user, userId)
     .then(() => dispatch(requestUsers(callBackFind)))
+    .then(() => dispatch(callBackUpdateTree))
     .catch(() => dispatch(fetchFailed));
 };
 

--- a/src/rbac-forms/rbacUserManagementModule/redux/actions/actions.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/actions/actions.js
@@ -1,0 +1,59 @@
+import { push } from 'connected-react-router';
+import {
+  LOAD_DATA,
+  SELECT_USERS,
+  SAVE_USER,
+  FETCH_DATA,
+  FETCH_SUCESFULL,
+  REQUEST_FAILED,
+  DELETE_USER,
+} from './actionTypes';
+
+export const navigate = where => dispatch => dispatch(push(where));
+
+export const loadUsersData = data => ({
+  type: LOAD_DATA,
+  data,
+});
+
+export const selectUsers = users => ({
+  type: SELECT_USERS,
+  selectedUsers: users,
+});
+
+const fetchData = type => ({
+  type,
+});
+
+const fetchSucesfull = () => ({
+  type: FETCH_SUCESFULL,
+});
+
+const fetchFailed = () => ({
+  type: REQUEST_FAILED,
+});
+
+export const requestUsers = callBack => (dispatch) => {
+  dispatch(fetchData(FETCH_DATA));
+  return callBack()
+    .then(data => dispatch(loadUsersData(data)))
+    .then(() => dispatch(fetchSucesfull()));
+};
+
+export const saveUser = (user, callBack) => (dispatch) => {
+  dispatch(fetchData(SAVE_USER));
+  return callBack(user)
+    .then(users => dispatch(loadUsersData(users)))
+    .then(() => dispatch(fetchSucesfull))
+    .then(() => dispatch(navigate('/')))
+    .catch(() => dispatch(fetchFailed));
+};
+
+export const deleteUser = (userId, callBack) => (dispatch) => {
+  dispatch(fetchData(DELETE_USER));
+  return callBack(userId)
+    .then(users => dispatch(loadUsersData(users)))
+    .then(() => dispatch(fetchSucesfull))
+    .then(() => dispatch(navigate('/')))
+    .catch(() => dispatch(fetchFailed));
+};

--- a/src/rbac-forms/rbacUserManagementModule/redux/data.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/data.js
@@ -1,0 +1,150 @@
+export const data = {
+  rows: [
+    {
+      id: 100,
+      name: 'Adam the first',
+      userid: 'Admin',
+      email: 'email@neco.com',
+      current_group: {
+        label: 'Some group',
+        onClick: () => console.log('Current group clicked'),
+      },
+      role: {
+        label: 'Admin role',
+        onClick: () => console.log('Current role click'),
+      },
+      groups: [{
+        label: 'Cloud-Operators',
+        icon: 'group',
+        groupId: 1,
+        onClick: () => console.log('Group click'),
+      }, {
+        label: 'Cloud-Users',
+        icon: 'group',
+        groupId: 2,
+        onClick: () => console.log('Group click'),
+      }],
+      lastlogon: '06/25/18 06:58:14 UTC',
+      lastlogoff: '06/30/18 06:58:14 UTC',
+    },
+    {
+      id: 101,
+      name: 'Marge the middle',
+      userid: 'La transparenza della qualita',
+      email: 'email@jandak.com',
+      current_group: {
+        label: 'Mediocre group',
+        onClick: () => console.log('Current group clicked'),
+      },
+      role: {
+        label: 'Shot role',
+        onClick: () => console.log('Current role click'),
+      },
+      groups: [{
+        label: 'Cloud-Operators',
+        icon: 'group',
+        groupId: 1,
+        onClick: () => console.log('Group click'),
+      }, {
+        label: 'Cloud-Users',
+        icon: 'group',
+        groupId: 2,
+        onClick: () => console.log('Group click'),
+      }],
+      lastlogon: '01/25/18 06:58:14 UTC',
+      lastlogoff: '06/30/18 06:58:14 UTC',
+    },
+    {
+      id: 102,
+      name: 'Zlatko the last',
+      userid: 'Peligro',
+      email: 'email@jandak.com',
+      current_group: {
+        label: 'Admin group',
+        onClick: () => console.log('Current group clicked'),
+      },
+      role: {
+        label: 'Cloud-Users',
+        onClick: () => console.log('Current role click'),
+      },
+      groups: [{
+        label: 'Cloud-Operators',
+        icon: 'group',
+        groupId: 1,
+        onClick: () => console.log('Group click'),
+      }, {
+        label: 'Cloud-Users',
+        icon: 'group',
+        groupId: 2,
+        onClick: () => console.log('Group click'),
+      }],
+      lastlogon: '08/25/18 06:58:14 UTC',
+      lastlogoff: '010/30/18 06:58:14 UTC',
+    },
+  ],
+  columns: [{
+    property: 'name',
+    label: 'Full Name',
+  }, {
+    property: 'userid',
+    label: 'Username',
+  }, {
+    property: 'email',
+    label: 'E-mail',
+  }, {
+    property: 'current_group',
+    label: 'Current Group',
+  }, {
+    property: 'role',
+    label: 'Role',
+  }, {
+    property: 'lastlogon',
+    label: 'Last Logon',
+  }, {
+    property: 'lastlogoff',
+    label: 'Last Logoff',
+  }],
+  selectedUsers: null,
+  groups: [
+    {
+      value: 1,
+      label: 'Hope',
+    },
+    {
+      value: 2,
+      label: 'Christa',
+    },
+    {
+      value: 3,
+      label: 'Tania',
+    },
+    {
+      value: 4,
+      label: 'Mcintyre',
+    },
+    {
+      value: 5,
+      label: 'Tonya',
+    },
+    {
+      value: 6,
+      label: 'Marcie',
+    },
+    {
+      value: 7,
+      label: 'Cara',
+    },
+    {
+      value: 8,
+      label: 'Becker',
+    },
+    {
+      value: 9,
+      label: 'Foley',
+    },
+    {
+      value: 10,
+      label: 'Perkins',
+    },
+  ],
+};

--- a/src/rbac-forms/rbacUserManagementModule/redux/reducers/index.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/reducers/index.js
@@ -1,0 +1,13 @@
+import { createHashHistory } from 'history';
+import { applyMiddleware, compose, createStore, combineReducers } from 'redux';
+import { connectRouter, routerMiddleware } from 'connected-react-router';
+import thunk from 'redux-thunk';
+import usersReducer from './usersReducer';
+
+export const history = createHashHistory();
+
+export const store = createStore(
+  connectRouter(history)(combineReducers({ usersReducer })),
+  // eslint-disable-next-line
+  compose(applyMiddleware(thunk, routerMiddleware(history)) , window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()),
+);

--- a/src/rbac-forms/rbacUserManagementModule/redux/reducers/usersReducer.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/reducers/usersReducer.js
@@ -1,0 +1,31 @@
+import {
+  LOAD_DATA,
+  SELECT_USERS,
+  FETCH_DATA,
+  FETCH_SUCESFULL,
+  REQUEST_FAILED,
+} from '../actions/actionTypes';
+
+const usersReducer = (state = { isLoaded: false, isFetching: false, isValid: true }, action) => {
+  switch (action.type) {
+    case FETCH_SUCESFULL:
+      return { ...state, isFetching: false, isValid: true };
+    case REQUEST_FAILED:
+      return { ...state, isFetching: false, isValid: false };
+    case FETCH_DATA:
+      return { ...state, isFetching: true };
+    case LOAD_DATA:
+      return {
+        ...action.data,
+        isLoaded: true,
+        isFetching: false,
+        isValid: true,
+      };
+    case SELECT_USERS:
+      return { ...state, selectedUsers: action.selectedUsers };
+    default:
+      return { ...state };
+  }
+};
+
+export default usersReducer;

--- a/src/rbac-forms/rbacUserManagementModule/redux/reducers/usersReducer.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/reducers/usersReducer.js
@@ -4,6 +4,7 @@ import {
   FETCH_DATA,
   FETCH_SUCESFULL,
   REQUEST_FAILED,
+  SAVE_USER,
 } from '../actions/actionTypes';
 
 const usersReducer = (state = { isLoaded: false, isFetching: false, isValid: true }, action) => {
@@ -13,6 +14,7 @@ const usersReducer = (state = { isLoaded: false, isFetching: false, isValid: tru
     case REQUEST_FAILED:
       return { ...state, isFetching: false, isValid: false };
     case FETCH_DATA:
+    case SAVE_USER:
       return { ...state, isFetching: true };
     case LOAD_DATA:
       return {

--- a/src/rbac-forms/rbacUserManagementModule/redux/reducers/usersReducer.js
+++ b/src/rbac-forms/rbacUserManagementModule/redux/reducers/usersReducer.js
@@ -5,9 +5,11 @@ import {
   FETCH_SUCESFULL,
   REQUEST_FAILED,
   SAVE_USER,
+  STORE_GROUPS,
 } from '../actions/actionTypes';
 
 const usersReducer = (state = { isLoaded: false, isFetching: false, isValid: true }, action) => {
+  let newState = {};
   switch (action.type) {
     case FETCH_SUCESFULL:
       return { ...state, isFetching: false, isValid: true };
@@ -17,14 +19,19 @@ const usersReducer = (state = { isLoaded: false, isFetching: false, isValid: tru
     case SAVE_USER:
       return { ...state, isFetching: true };
     case LOAD_DATA:
-      return {
-        ...action.data,
+      newState = {
+        ...state,
+        rows: [...action.data.rows],
+        columns: action.data.columns || { ...state.columns },
         isLoaded: true,
         isFetching: false,
         isValid: true,
       };
+      return { ...newState };
     case SELECT_USERS:
       return { ...state, selectedUsers: action.selectedUsers };
+    case STORE_GROUPS:
+      return { ...state, groups: action.groups };
     default:
       return { ...state };
   }

--- a/src/rbac-forms/rbacUserPreview.jsx
+++ b/src/rbac-forms/rbacUserPreview.jsx
@@ -75,7 +75,7 @@ RbacUserPreview.propTypes = {
     name: PropTypes.string.isRequired,
     userid: PropTypes.string.isRequired,
     email: (props, propName, componentName) => (
-      emailPattern.test(props[propName])
+      !props[propName] || emailPattern.test(props[propName])
         ? undefined
         : new Error(`Invalid prop  ${propName} supplied to ${componentName} Validation failed. Expect email address.`)
     ),
@@ -86,7 +86,7 @@ RbacUserPreview.propTypes = {
     groups: PropTypes.arrayOf(PropTypes.shape({
       label: PropTypes.string.isRequired,
       icon: PropTypes.string.isRequired,
-      groupId: PropTypes.number.isRequired,
+      groupId: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     })),
     role: PropTypes.shape({

--- a/src/rbac-forms/rbacUserTagsList.jsx
+++ b/src/rbac-forms/rbacUserTagsList.jsx
@@ -1,0 +1,35 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from 'patternfly-react';
+import { __, sprintf } from '../global-functions';
+
+const renderTags = tags => tags.map(({ name, value }) => <Fragment key={name}><Icon type="fa" name="tag" /> {`${name}: ${value}`}<br /></Fragment>);
+
+const RbacUserTagsList = ({ tags, tenant }) => (
+  <div>
+    <h3>{__('Smart Management')}</h3>
+    <div className="form-horizontal static">
+      <div className="form-group">
+        <label className="col-md-2 control-label"> { /* eslint-disable-line */ }
+          {sprintf(__('%s Tags'), tenant)}
+        </label>
+        <div className="col-md-8">
+          {tags && tags.length > 0 ?
+            renderTags(tags) : <span><Icon type="fa" name="tag" /> {sprintf(__('No %s Tags have been assigned'), tenant)}</span>}
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+RbacUserTagsList.propTypes = {
+  tags: PropTypes.array,
+  tenant: PropTypes.string,
+};
+
+RbacUserTagsList.defaultProps = {
+  tenant: '',
+  tags: [],
+};
+
+export default RbacUserTagsList;

--- a/src/rbac-forms/stories/data.js
+++ b/src/rbac-forms/stories/data.js
@@ -1,3 +1,5 @@
+import { action } from '@storybook/addon-actions';
+
 export const groups = [
   {
     value: 1,
@@ -40,6 +42,12 @@ export const groups = [
     label: 'Perkins',
   },
 ];
+
+export const editedUser = {
+  name: 'Users full name',
+  userid: 'admin jiny',
+  chosen_group: [5, 7],
+};
 
 export const usersTableColumns = [{
   property: 'fullname',
@@ -96,3 +104,28 @@ export const usersTableRows = [
     lastlogoff: '010/30/18 06:58:14 UTC',
   },
 ];
+
+export const user = {
+  name: 'Administrator',
+  userid: 'Admin',
+  email: 'mail@mail.com',
+  current_group: {
+    label: 'EvmGroup-super_administrator',
+    onClick: () => action('Current group clicked'),
+  },
+  groups: [{
+    label: 'Cloud-Operators',
+    icon: 'group',
+    groupId: 1,
+    onClick: () => action('Group click'),
+  }, {
+    label: 'Cloud-Users',
+    icon: 'group',
+    groupId: 2,
+    onClick: () => action('Group click'),
+  }],
+  role: {
+    label: 'Cloud-Users',
+    onClick: () => action('Current role click'),
+  },
+};

--- a/src/rbac-forms/stories/rbacUserForm.stories.js
+++ b/src/rbac-forms/stories/rbacUserForm.stories.js
@@ -4,38 +4,21 @@ import { action } from '@storybook/addon-actions';
 import { withInfo } from '@storybook/addon-info';
 import { RbacUserForm, RbacUserPreview } from '../';
 import { GenericPreviewTable } from '../../table/';
-import { groups, usersTableColumns, usersTableRows } from './data';
-
-const user = {
-  name: 'Administrator',
-  userid: 'Admin',
-  email: 'mail@mail.com',
-  current_group: {
-    label: 'EvmGroup-super_administrator',
-    onClick: () => action('Current group clicked'),
-  },
-  groups: [{
-    label: 'Cloud-Operators',
-    icon: 'group',
-    groupId: 1,
-    onClick: () => action('Group click'),
-  }, {
-    label: 'Cloud-Users',
-    icon: 'group',
-    groupId: 2,
-    onClick: () => action('Group click'),
-  }],
-  role: {
-    label: 'Cloud-Users',
-    onClick: () => action('Current role click'),
-  },
-};
+import { groups, usersTableColumns, usersTableRows, user, editedUser } from './data';
 
 storiesOf('Rbac forms', module).add('Rbac add user form', withInfo()(() => (
   <RbacUserForm
     groups={groups}
     onSave={action('onSave')}
     onCancel={action('onCancel')}
+  />
+))).add('Rbac edit user form', withInfo()(() => (
+  <RbacUserForm
+    groups={groups}
+    onSave={action('onSave')}
+    onCancel={action('onCancel')}
+    initialValues={editedUser}
+    editDisabled={false}
   />
 ))).add('Rbac user preview', withInfo()(() => (
   <RbacUserPreview user={user} />

--- a/src/rbac-forms/stories/rbacUserForm.stories.js
+++ b/src/rbac-forms/stories/rbacUserForm.stories.js
@@ -5,6 +5,7 @@ import { withInfo } from '@storybook/addon-info';
 import { RbacUserForm, RbacUserPreview } from '../';
 import { GenericPreviewTable } from '../../table/';
 import { groups, usersTableColumns, usersTableRows, user, editedUser } from './data';
+import RbacUserManagementModule from '../rbacUserManagementModule';
 
 storiesOf('Rbac forms', module).add('Rbac add user form', withInfo()(() => (
   <RbacUserForm
@@ -22,17 +23,34 @@ storiesOf('Rbac forms', module).add('Rbac add user form', withInfo()(() => (
   />
 ))).add('Rbac user preview', withInfo()(() => (
   <RbacUserPreview user={user} />
-))).add('Rbac users table', withInfo()(() => (
-  <GenericPreviewTable
-    rows={usersTableRows}
-    columns={usersTableColumns}
-    rowClick={action('Row clicked')}
-    rowSelect={action('User selected')}
-    showIcon
-    showSelect
-    icon={{
-      type: 'pf',
-      name: 'user',
-    }}
-  />
-)));
+)))
+  .add('Rbac users table', withInfo()(() => (
+    <GenericPreviewTable
+      rows={usersTableRows}
+      columns={usersTableColumns}
+      rowClick={action('Row clicked')}
+      rowSelect={action('User selected')}
+      showIcon
+      showSelect
+      icon={{
+        type: 'pf',
+        name: 'user',
+      }}
+    />
+  )))
+  .add('Rbac complex demo', withInfo()(() => (
+    <div style={{ margin: 15 }}>
+      <div>
+        <p>This is a demo of several component that should replace current UI in user management in ManageIQ-ui-classic.</p>
+        <p>
+          Main feture of this is to show Redux based front-end routing.
+          That will add routing to user management, without breaking any server routes.
+        </p>
+        <p>
+          The to button toolbar and the left list, are not part of React router, but they act as Link components.
+          They are connected to calling redux actions, manipulating the URL and invoking re-rendering.
+        </p>
+      </div>
+      <RbacUserManagementModule />
+    </div>
+  )));

--- a/src/rbac-forms/styles.scss
+++ b/src/rbac-forms/styles.scss
@@ -3,3 +3,21 @@
     min-height: 11px;
   }
 }
+
+.button-link {
+  border: none;
+  padding-left: 0;
+  padding-right: 0;
+  color: #0099d3;
+  cursor: pointer;
+  background: none;
+
+  &:hover {
+    color: #00659c;
+    text-decoration: underline;
+  }
+
+  &:focus {
+    outline:none;
+  }
+}

--- a/src/rbac-forms/tests/__snapshots__/rbacUserForm.test.jsx.snap
+++ b/src/rbac-forms/tests/__snapshots__/rbacUserForm.test.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`RbacUserForm component Should render correctly 1`] = `
 <RbacUserForm
+  editDisabled={false}
   groups={
     Array [
       Object {
@@ -424,53 +425,26 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                     </Field>
                   </div>
                 </Col>
-                <Col
-                  bsClass="col"
-                  componentClass="div"
-                  xs={12}
+                <PasswordFragment
+                  changeValue={[Function]}
+                  isEditing={false}
                 >
-                  <div
-                    className="col-xs-12"
+                  <Col
+                    bsClass="col"
+                    componentClass="div"
+                    xs={12}
                   >
-                    <Field
-                      component={[Function]}
-                      format={[Function]}
-                      label="Password"
-                      name="password"
-                      parse={[Function]}
-                      type="password"
-                      validate={[Function]}
+                    <div
+                      className="col-xs-12"
                     >
-                      <FinalFormField
-                        input={
-                          Object {
-                            "name": "password",
-                            "onBlur": [Function],
-                            "onChange": [Function],
-                            "onFocus": [Function],
-                            "value": "",
-                          }
-                        }
+                      <Field
+                        component={[Function]}
+                        format={[Function]}
                         label="Password"
-                        meta={
-                          Object {
-                            "active": false,
-                            "data": Object {},
-                            "dirty": false,
-                            "dirtySinceLastSubmit": false,
-                            "error": "Required",
-                            "initial": undefined,
-                            "invalid": true,
-                            "pristine": true,
-                            "submitError": undefined,
-                            "submitFailed": false,
-                            "submitSucceeded": false,
-                            "touched": false,
-                            "valid": false,
-                            "visited": false,
-                          }
-                        }
+                        name="password"
+                        parse={[Function]}
                         type="password"
+                        validate={[Function]}
                       >
                         <FinalFormComponent
                           clearable={false}
@@ -485,10 +459,7 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                               "value": "",
                             }
                           }
-                          inputColumnSize={8}
                           label="Password"
-                          labelColumnSize={2}
-                          labelKey="label"
                           meta={
                             Object {
                               "active": false,
@@ -507,39 +478,73 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                               "visited": false,
                             }
                           }
-                          multi={false}
-                          placeholder=""
-                          searchable={false}
                           type="password"
-                          validateOnMount={false}
-                          valueKey="value"
                         >
-                          <FormGroup
-                            bsClass="form-group"
-                            validationState={null}
+                          <FinalFormComponent
+                            clearable={false}
+                            componentType="textfield"
+                            disabled={false}
+                            input={
+                              Object {
+                                "name": "password",
+                                "onBlur": [Function],
+                                "onChange": [Function],
+                                "onFocus": [Function],
+                                "value": "",
+                              }
+                            }
+                            inputColumnSize={8}
+                            label="Password"
+                            labelColumnSize={2}
+                            labelKey="label"
+                            meta={
+                              Object {
+                                "active": false,
+                                "data": Object {},
+                                "dirty": false,
+                                "dirtySinceLastSubmit": false,
+                                "error": "Required",
+                                "initial": undefined,
+                                "invalid": true,
+                                "pristine": true,
+                                "submitError": undefined,
+                                "submitFailed": false,
+                                "submitSucceeded": false,
+                                "touched": false,
+                                "valid": false,
+                                "visited": false,
+                              }
+                            }
+                            multi={false}
+                            placeholder=""
+                            searchable={false}
+                            type="password"
+                            validateOnMount={false}
+                            valueKey="value"
                           >
-                            <div
-                              className="form-group"
+                            <FormGroup
+                              bsClass="form-group"
+                              validationState={null}
                             >
-                              <Col
-                                bsClass="col"
-                                className="control-label"
-                                componentClass="label"
-                                xs={2}
+                              <div
+                                className="form-group"
                               >
-                                <label
-                                  className="control-label col-xs-2"
+                                <Col
+                                  bsClass="col"
+                                  className="control-label"
+                                  componentClass="label"
+                                  xs={2}
                                 >
-                                  Password
-                                </label>
-                              </Col>
-                              <Col
-                                bsClass="col"
-                                componentClass="div"
-                                xs={8}
-                              >
-                                <div
-                                  className="col-xs-8"
+                                  <label
+                                    className="control-label col-xs-2"
+                                  >
+                                    Password
+                                  </label>
+                                </Col>
+                                <Col
+                                  bsClass="col"
+                                  componentClass="div"
+                                  xs={8}
                                 >
                                   <FormControl
                                     bsClass="form-control"
@@ -565,64 +570,45 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                                       placeholder=""
                                       type="password"
                                       value=""
-                                    />
-                                  </FormControl>
-                                </div>
-                              </Col>
-                            </div>
-                          </FormGroup>
-                        </FinalFormComponent>
-                      </FinalFormField>
-                    </Field>
-                  </div>
-                </Col>
-                <Col
-                  bsClass="col"
-                  componentClass="div"
-                  xs={12}
-                >
-                  <div
-                    className="col-xs-12"
+                                    >
+                                      <input
+                                        className="form-control"
+                                        disabled={false}
+                                        id="password"
+                                        name="password"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        placeholder=""
+                                        type="password"
+                                        value=""
+                                      />
+                                    </FormControl>
+                                  </div>
+                                </Col>
+                              </div>
+                            </FormGroup>
+                          </FinalFormComponent>
+                        </FinalFormField>
+                      </Field>
+                    </div>
+                  </Col>
+                  <Col
+                    bsClass="col"
+                    componentClass="div"
+                    xs={12}
                   >
-                    <Field
-                      component={[Function]}
-                      format={[Function]}
-                      label="Confirm password"
-                      name="verify"
-                      parse={[Function]}
-                      type="password"
-                      validate={[Function]}
+                    <div
+                      className="col-xs-12"
                     >
-                      <FinalFormField
-                        input={
-                          Object {
-                            "name": "verify",
-                            "onBlur": [Function],
-                            "onChange": [Function],
-                            "onFocus": [Function],
-                            "value": "",
-                          }
-                        }
+                      <Field
+                        component={[Function]}
+                        format={[Function]}
                         label="Confirm password"
-                        meta={
-                          Object {
-                            "active": false,
-                            "data": Object {},
-                            "dirty": false,
-                            "dirtySinceLastSubmit": false,
-                            "error": "Required",
-                            "initial": undefined,
-                            "invalid": true,
-                            "pristine": true,
-                            "submitError": undefined,
-                            "submitFailed": false,
-                            "submitSucceeded": false,
-                            "touched": false,
-                            "valid": false,
-                            "visited": false,
-                          }
-                        }
+                        name="verify"
+                        parse={[Function]}
                         type="password"
+                        validate={[Function]}
                       >
                         <FinalFormComponent
                           clearable={false}
@@ -637,10 +623,7 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                               "value": "",
                             }
                           }
-                          inputColumnSize={8}
                           label="Confirm password"
-                          labelColumnSize={2}
-                          labelKey="label"
                           meta={
                             Object {
                               "active": false,
@@ -659,39 +642,73 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                               "visited": false,
                             }
                           }
-                          multi={false}
-                          placeholder=""
-                          searchable={false}
                           type="password"
-                          validateOnMount={false}
-                          valueKey="value"
                         >
-                          <FormGroup
-                            bsClass="form-group"
-                            validationState={null}
+                          <FinalFormComponent
+                            clearable={false}
+                            componentType="textfield"
+                            disabled={false}
+                            input={
+                              Object {
+                                "name": "verify",
+                                "onBlur": [Function],
+                                "onChange": [Function],
+                                "onFocus": [Function],
+                                "value": "",
+                              }
+                            }
+                            inputColumnSize={8}
+                            label="Confirm password"
+                            labelColumnSize={2}
+                            labelKey="label"
+                            meta={
+                              Object {
+                                "active": false,
+                                "data": Object {},
+                                "dirty": false,
+                                "dirtySinceLastSubmit": false,
+                                "error": "Required",
+                                "initial": undefined,
+                                "invalid": true,
+                                "pristine": true,
+                                "submitError": undefined,
+                                "submitFailed": false,
+                                "submitSucceeded": false,
+                                "touched": false,
+                                "valid": false,
+                                "visited": false,
+                              }
+                            }
+                            multi={false}
+                            placeholder=""
+                            searchable={false}
+                            type="password"
+                            validateOnMount={false}
+                            valueKey="value"
                           >
-                            <div
-                              className="form-group"
+                            <FormGroup
+                              bsClass="form-group"
+                              validationState={null}
                             >
-                              <Col
-                                bsClass="col"
-                                className="control-label"
-                                componentClass="label"
-                                xs={2}
+                              <div
+                                className="form-group"
                               >
-                                <label
-                                  className="control-label col-xs-2"
+                                <Col
+                                  bsClass="col"
+                                  className="control-label"
+                                  componentClass="label"
+                                  xs={2}
                                 >
-                                  Confirm password
-                                </label>
-                              </Col>
-                              <Col
-                                bsClass="col"
-                                componentClass="div"
-                                xs={8}
-                              >
-                                <div
-                                  className="col-xs-8"
+                                  <label
+                                    className="control-label col-xs-2"
+                                  >
+                                    Confirm password
+                                  </label>
+                                </Col>
+                                <Col
+                                  bsClass="col"
+                                  componentClass="div"
+                                  xs={8}
                                 >
                                   <FormControl
                                     bsClass="form-control"
@@ -717,17 +734,30 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                                       placeholder=""
                                       type="password"
                                       value=""
-                                    />
-                                  </FormControl>
-                                </div>
-                              </Col>
-                            </div>
-                          </FormGroup>
-                        </FinalFormComponent>
-                      </FinalFormField>
-                    </Field>
-                  </div>
-                </Col>
+                                    >
+                                      <input
+                                        className="form-control"
+                                        disabled={false}
+                                        id="verify"
+                                        name="verify"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        placeholder=""
+                                        type="password"
+                                        value=""
+                                      />
+                                    </FormControl>
+                                  </div>
+                                </Col>
+                              </div>
+                            </FormGroup>
+                          </FinalFormComponent>
+                        </FinalFormField>
+                      </Field>
+                    </div>
+                  </Col>
+                </PasswordFragment>
                 <Col
                   bsClass="col"
                   componentClass="div"

--- a/src/rbac-forms/tests/__snapshots__/rbacUserForm.test.jsx.snap
+++ b/src/rbac-forms/tests/__snapshots__/rbacUserForm.test.jsx.snap
@@ -440,6 +440,7 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                       <Field
                         component={[Function]}
                         format={[Function]}
+                        id="password"
                         label="Password"
                         name="password"
                         parse={[Function]}
@@ -484,6 +485,7 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                             clearable={false}
                             componentType="textfield"
                             disabled={false}
+                            id="password"
                             input={
                               Object {
                                 "name": "password",
@@ -604,6 +606,7 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                       <Field
                         component={[Function]}
                         format={[Function]}
+                        id="password-verify"
                         label="Confirm password"
                         name="verify"
                         parse={[Function]}
@@ -648,6 +651,7 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                             clearable={false}
                             componentType="textfield"
                             disabled={false}
+                            id="password-verify"
                             input={
                               Object {
                                 "name": "verify",
@@ -1555,6 +1559,1485 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                             type="button"
                           >
                             Add
+                          </button>
+                        </Button>
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
+                          bsStyle="default"
+                          disabled={false}
+                          onClick={[MockFunction]}
+                        >
+                          <button
+                            className="btn btn-default"
+                            disabled={false}
+                            onClick={[MockFunction]}
+                            type="button"
+                          >
+                            Cancel
+                          </button>
+                        </Button>
+                      </div>
+                    </ButtonGroup>
+                  </div>
+                </Col>
+              </div>
+            </Row>
+          </div>
+        </Grid>
+      </form>
+    </Form>
+  </ReactFinalForm>
+</RbacUserForm>
+`;
+
+exports[`RbacUserForm component Should render editing version 1`] = `
+<RbacUserForm
+  editDisabled={false}
+  editEnabled={true}
+  groups={
+    Array [
+      Object {
+        "label": "ckeller",
+        "value": 10000000000029,
+      },
+      Object {
+        "label": "Cloud-Operators",
+        "value": 10000000000025,
+      },
+      Object {
+        "label": "Cloud-Users",
+        "value": 10000000000026,
+      },
+      Object {
+        "label": "EvmGroup-administrator",
+        "value": 10000000000005,
+      },
+      Object {
+        "label": "EvmGroup-approver",
+        "value": 10000000000006,
+      },
+      Object {
+        "label": "EvmGroup-auditor",
+        "value": 10000000000007,
+      },
+      Object {
+        "label": "EvmGroup-consumption_administrator",
+        "value": 10000000000016,
+      },
+      Object {
+        "label": "EvmGroup-container_administrator",
+        "value": 10000000000017,
+      },
+      Object {
+        "label": "EvmGroup-container_operator",
+        "value": 10000000000018,
+      },
+      Object {
+        "label": "EvmGroup-desktop",
+        "value": 10000000000011,
+      },
+      Object {
+        "label": "EvmGroup-operator",
+        "value": 10000000000003,
+      },
+      Object {
+        "label": "EvmGroup-reader",
+        "value": 10000000000036,
+      },
+      Object {
+        "label": "EvmGroup-security",
+        "value": 10000000000010,
+      },
+      Object {
+        "label": "EvmGroup-super_administrator",
+        "value": 10000000000002,
+      },
+      Object {
+        "label": "EvmGroup-support",
+        "value": 10000000000008,
+      },
+      Object {
+        "label": "EvmGroup-tenant_administrator",
+        "value": 10000000000014,
+      },
+      Object {
+        "label": "EvmGroup-tenant_quota_administrator",
+        "value": 10000000000015,
+      },
+      Object {
+        "label": "EvmGroup-user",
+        "value": 10000000000004,
+      },
+      Object {
+        "label": "EvmGroup-user_limited_self_service",
+        "value": 10000000000013,
+      },
+      Object {
+        "label": "EvmGroup-user_self_service",
+        "value": 10000000000012,
+      },
+      Object {
+        "label": "EvmGroup-vm_user",
+        "value": 10000000000009,
+      },
+      Object {
+        "label": "loic Group",
+        "value": 10000000000034,
+      },
+    ]
+  }
+  initialValues={
+    Object {
+      "email": "email@mail.com",
+      "group": Array [
+        10000000000026,
+        10000000000016,
+      ],
+      "name": "User name",
+      "userid": "User id",
+    }
+  }
+  onCancel={[MockFunction]}
+  onSave={[MockFunction]}
+>
+  <ReactFinalForm
+    initialValues={
+      Object {
+        "email": "email@mail.com",
+        "group": Array [
+          10000000000026,
+          10000000000016,
+        ],
+        "name": "User name",
+        "userid": "User id",
+      }
+    }
+    onSubmit={[Function]}
+    render={[Function]}
+    validate={[Function]}
+  >
+    <Form
+      bsClass="form"
+      componentClass="form"
+      horizontal={true}
+      inline={false}
+    >
+      <form
+        className="form-horizontal"
+      >
+        <Grid
+          bsClass="container"
+          componentClass="div"
+          fluid={false}
+        >
+          <div
+            className="container"
+          >
+            <Row
+              bsClass="row"
+              componentClass="div"
+            >
+              <div
+                className="row"
+              >
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                  xs={12}
+                >
+                  <div
+                    className="col-xs-12"
+                  >
+                    <Field
+                      component={[Function]}
+                      disabled={false}
+                      format={[Function]}
+                      label="Full Name"
+                      name="name"
+                      parse={[Function]}
+                      validate={[Function]}
+                    >
+                      <FinalFormField
+                        disabled={false}
+                        input={
+                          Object {
+                            "name": "name",
+                            "onBlur": [Function],
+                            "onChange": [Function],
+                            "onFocus": [Function],
+                            "value": "User name",
+                          }
+                        }
+                        label="Full Name"
+                        meta={
+                          Object {
+                            "active": false,
+                            "data": Object {},
+                            "dirty": false,
+                            "dirtySinceLastSubmit": false,
+                            "error": undefined,
+                            "initial": "User name",
+                            "invalid": false,
+                            "pristine": true,
+                            "submitError": undefined,
+                            "submitFailed": false,
+                            "submitSucceeded": false,
+                            "touched": false,
+                            "valid": true,
+                            "visited": false,
+                          }
+                        }
+                      >
+                        <FinalFormComponent
+                          clearable={false}
+                          componentType="textfield"
+                          disabled={false}
+                          input={
+                            Object {
+                              "name": "name",
+                              "onBlur": [Function],
+                              "onChange": [Function],
+                              "onFocus": [Function],
+                              "value": "User name",
+                            }
+                          }
+                          inputColumnSize={8}
+                          label="Full Name"
+                          labelColumnSize={2}
+                          labelKey="label"
+                          meta={
+                            Object {
+                              "active": false,
+                              "data": Object {},
+                              "dirty": false,
+                              "dirtySinceLastSubmit": false,
+                              "error": undefined,
+                              "initial": "User name",
+                              "invalid": false,
+                              "pristine": true,
+                              "submitError": undefined,
+                              "submitFailed": false,
+                              "submitSucceeded": false,
+                              "touched": false,
+                              "valid": true,
+                              "visited": false,
+                            }
+                          }
+                          multi={false}
+                          placeholder=""
+                          searchable={false}
+                          validateOnMount={false}
+                          valueKey="value"
+                        >
+                          <FormGroup
+                            bsClass="form-group"
+                            validationState={null}
+                          >
+                            <div
+                              className="form-group"
+                            >
+                              <Col
+                                bsClass="col"
+                                className="control-label"
+                                componentClass="label"
+                                xs={2}
+                              >
+                                <label
+                                  className="control-label col-xs-2"
+                                >
+                                  Full Name
+                                </label>
+                              </Col>
+                              <Col
+                                bsClass="col"
+                                componentClass="div"
+                                xs={8}
+                              >
+                                <div
+                                  className="col-xs-8"
+                                >
+                                  <FormControl
+                                    bsClass="form-control"
+                                    componentClass="input"
+                                    disabled={false}
+                                    id="name"
+                                    name="name"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    placeholder=""
+                                    type="text"
+                                    value="User name"
+                                  >
+                                    <input
+                                      className="form-control"
+                                      disabled={false}
+                                      id="name"
+                                      name="name"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      placeholder=""
+                                      type="text"
+                                      value="User name"
+                                    />
+                                  </FormControl>
+                                </div>
+                              </Col>
+                            </div>
+                          </FormGroup>
+                        </FinalFormComponent>
+                      </FinalFormField>
+                    </Field>
+                  </div>
+                </Col>
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                  xs={12}
+                >
+                  <div
+                    className="col-xs-12"
+                  >
+                    <Field
+                      component={[Function]}
+                      disabled={false}
+                      format={[Function]}
+                      label="Username"
+                      name="userid"
+                      parse={[Function]}
+                      validate={[Function]}
+                    >
+                      <FinalFormField
+                        disabled={false}
+                        input={
+                          Object {
+                            "name": "userid",
+                            "onBlur": [Function],
+                            "onChange": [Function],
+                            "onFocus": [Function],
+                            "value": "User id",
+                          }
+                        }
+                        label="Username"
+                        meta={
+                          Object {
+                            "active": false,
+                            "data": Object {},
+                            "dirty": false,
+                            "dirtySinceLastSubmit": false,
+                            "error": undefined,
+                            "initial": "User id",
+                            "invalid": false,
+                            "pristine": true,
+                            "submitError": undefined,
+                            "submitFailed": false,
+                            "submitSucceeded": false,
+                            "touched": false,
+                            "valid": true,
+                            "visited": false,
+                          }
+                        }
+                      >
+                        <FinalFormComponent
+                          clearable={false}
+                          componentType="textfield"
+                          disabled={false}
+                          input={
+                            Object {
+                              "name": "userid",
+                              "onBlur": [Function],
+                              "onChange": [Function],
+                              "onFocus": [Function],
+                              "value": "User id",
+                            }
+                          }
+                          inputColumnSize={8}
+                          label="Username"
+                          labelColumnSize={2}
+                          labelKey="label"
+                          meta={
+                            Object {
+                              "active": false,
+                              "data": Object {},
+                              "dirty": false,
+                              "dirtySinceLastSubmit": false,
+                              "error": undefined,
+                              "initial": "User id",
+                              "invalid": false,
+                              "pristine": true,
+                              "submitError": undefined,
+                              "submitFailed": false,
+                              "submitSucceeded": false,
+                              "touched": false,
+                              "valid": true,
+                              "visited": false,
+                            }
+                          }
+                          multi={false}
+                          placeholder=""
+                          searchable={false}
+                          validateOnMount={false}
+                          valueKey="value"
+                        >
+                          <FormGroup
+                            bsClass="form-group"
+                            validationState={null}
+                          >
+                            <div
+                              className="form-group"
+                            >
+                              <Col
+                                bsClass="col"
+                                className="control-label"
+                                componentClass="label"
+                                xs={2}
+                              >
+                                <label
+                                  className="control-label col-xs-2"
+                                >
+                                  Username
+                                </label>
+                              </Col>
+                              <Col
+                                bsClass="col"
+                                componentClass="div"
+                                xs={8}
+                              >
+                                <div
+                                  className="col-xs-8"
+                                >
+                                  <FormControl
+                                    bsClass="form-control"
+                                    componentClass="input"
+                                    disabled={false}
+                                    id="userid"
+                                    name="userid"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    placeholder=""
+                                    type="text"
+                                    value="User id"
+                                  >
+                                    <input
+                                      className="form-control"
+                                      disabled={false}
+                                      id="userid"
+                                      name="userid"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      placeholder=""
+                                      type="text"
+                                      value="User id"
+                                    />
+                                  </FormControl>
+                                </div>
+                              </Col>
+                            </div>
+                          </FormGroup>
+                        </FinalFormComponent>
+                      </FinalFormField>
+                    </Field>
+                  </div>
+                </Col>
+                <PasswordFragment
+                  changeValue={[Function]}
+                  isEditing={true}
+                >
+                  <Col
+                    bsClass="col"
+                    componentClass="div"
+                    xs={12}
+                  >
+                    <div
+                      className="col-xs-12"
+                    >
+                      <Field
+                        component={[Function]}
+                        disabled={true}
+                        format={[Function]}
+                        label="Password"
+                        name="password"
+                        parse={[Function]}
+                        placeholder="●●●●●●●●"
+                        type="password"
+                      >
+                        <FinalFormField
+                          disabled={true}
+                          input={
+                            Object {
+                              "name": "password",
+                              "onBlur": [Function],
+                              "onChange": [Function],
+                              "onFocus": [Function],
+                              "value": "",
+                            }
+                          }
+                          label="Password"
+                          meta={
+                            Object {
+                              "active": false,
+                              "data": Object {},
+                              "dirty": false,
+                              "dirtySinceLastSubmit": false,
+                              "error": undefined,
+                              "initial": undefined,
+                              "invalid": false,
+                              "pristine": true,
+                              "submitError": undefined,
+                              "submitFailed": false,
+                              "submitSucceeded": false,
+                              "touched": false,
+                              "valid": true,
+                              "visited": false,
+                            }
+                          }
+                          placeholder="●●●●●●●●"
+                          type="password"
+                        >
+                          <FinalFormComponent
+                            clearable={false}
+                            componentType="textfield"
+                            disabled={true}
+                            input={
+                              Object {
+                                "name": "password",
+                                "onBlur": [Function],
+                                "onChange": [Function],
+                                "onFocus": [Function],
+                                "value": "",
+                              }
+                            }
+                            inputColumnSize={8}
+                            label="Password"
+                            labelColumnSize={2}
+                            labelKey="label"
+                            meta={
+                              Object {
+                                "active": false,
+                                "data": Object {},
+                                "dirty": false,
+                                "dirtySinceLastSubmit": false,
+                                "error": undefined,
+                                "initial": undefined,
+                                "invalid": false,
+                                "pristine": true,
+                                "submitError": undefined,
+                                "submitFailed": false,
+                                "submitSucceeded": false,
+                                "touched": false,
+                                "valid": true,
+                                "visited": false,
+                              }
+                            }
+                            multi={false}
+                            placeholder="●●●●●●●●"
+                            searchable={false}
+                            type="password"
+                            validateOnMount={false}
+                            valueKey="value"
+                          >
+                            <FormGroup
+                              bsClass="form-group"
+                              validationState={null}
+                            >
+                              <div
+                                className="form-group"
+                              >
+                                <Col
+                                  bsClass="col"
+                                  className="control-label"
+                                  componentClass="label"
+                                  xs={2}
+                                >
+                                  <label
+                                    className="control-label col-xs-2"
+                                  >
+                                    Password
+                                  </label>
+                                </Col>
+                                <Col
+                                  bsClass="col"
+                                  componentClass="div"
+                                  xs={8}
+                                >
+                                  <div
+                                    className="col-xs-8"
+                                  >
+                                    <FormControl
+                                      bsClass="form-control"
+                                      componentClass="input"
+                                      disabled={true}
+                                      id="password"
+                                      name="password"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      placeholder="●●●●●●●●"
+                                      type="password"
+                                      value=""
+                                    >
+                                      <input
+                                        className="form-control"
+                                        disabled={true}
+                                        id="password"
+                                        name="password"
+                                        onBlur={[Function]}
+                                        onChange={[Function]}
+                                        onFocus={[Function]}
+                                        placeholder="●●●●●●●●"
+                                        type="password"
+                                        value=""
+                                      />
+                                    </FormControl>
+                                  </div>
+                                </Col>
+                                <Col
+                                  bsClass="col"
+                                  componentClass="div"
+                                  md={2}
+                                >
+                                  <div
+                                    className="col-md-2"
+                                  >
+                                    <button
+                                      className="button-link"
+                                      id="password-change-enabler"
+                                      onClick={[Function]}
+                                      tabIndex="-1"
+                                      type="button"
+                                    >
+                                      Change stored password
+                                    </button>
+                                  </div>
+                                </Col>
+                              </div>
+                            </FormGroup>
+                          </FinalFormComponent>
+                        </FinalFormField>
+                      </Field>
+                    </div>
+                  </Col>
+                </PasswordFragment>
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                  xs={12}
+                >
+                  <div
+                    className="col-xs-12"
+                  >
+                    <Field
+                      component={[Function]}
+                      format={[Function]}
+                      label="Email Address"
+                      name="email"
+                      parse={[Function]}
+                      type="email"
+                      validate={[Function]}
+                    >
+                      <FinalFormField
+                        input={
+                          Object {
+                            "name": "email",
+                            "onBlur": [Function],
+                            "onChange": [Function],
+                            "onFocus": [Function],
+                            "value": "email@mail.com",
+                          }
+                        }
+                        label="Email Address"
+                        meta={
+                          Object {
+                            "active": false,
+                            "data": Object {},
+                            "dirty": false,
+                            "dirtySinceLastSubmit": false,
+                            "error": undefined,
+                            "initial": "email@mail.com",
+                            "invalid": false,
+                            "pristine": true,
+                            "submitError": undefined,
+                            "submitFailed": false,
+                            "submitSucceeded": false,
+                            "touched": false,
+                            "valid": true,
+                            "visited": false,
+                          }
+                        }
+                        type="email"
+                      >
+                        <FinalFormComponent
+                          clearable={false}
+                          componentType="textfield"
+                          disabled={false}
+                          input={
+                            Object {
+                              "name": "email",
+                              "onBlur": [Function],
+                              "onChange": [Function],
+                              "onFocus": [Function],
+                              "value": "email@mail.com",
+                            }
+                          }
+                          inputColumnSize={8}
+                          label="Email Address"
+                          labelColumnSize={2}
+                          labelKey="label"
+                          meta={
+                            Object {
+                              "active": false,
+                              "data": Object {},
+                              "dirty": false,
+                              "dirtySinceLastSubmit": false,
+                              "error": undefined,
+                              "initial": "email@mail.com",
+                              "invalid": false,
+                              "pristine": true,
+                              "submitError": undefined,
+                              "submitFailed": false,
+                              "submitSucceeded": false,
+                              "touched": false,
+                              "valid": true,
+                              "visited": false,
+                            }
+                          }
+                          multi={false}
+                          placeholder=""
+                          searchable={false}
+                          type="email"
+                          validateOnMount={false}
+                          valueKey="value"
+                        >
+                          <FormGroup
+                            bsClass="form-group"
+                            validationState={null}
+                          >
+                            <div
+                              className="form-group"
+                            >
+                              <Col
+                                bsClass="col"
+                                className="control-label"
+                                componentClass="label"
+                                xs={2}
+                              >
+                                <label
+                                  className="control-label col-xs-2"
+                                >
+                                  Email Address
+                                </label>
+                              </Col>
+                              <Col
+                                bsClass="col"
+                                componentClass="div"
+                                xs={8}
+                              >
+                                <div
+                                  className="col-xs-8"
+                                >
+                                  <FormControl
+                                    bsClass="form-control"
+                                    componentClass="input"
+                                    disabled={false}
+                                    id="email"
+                                    name="email"
+                                    onBlur={[Function]}
+                                    onChange={[Function]}
+                                    onFocus={[Function]}
+                                    placeholder=""
+                                    type="email"
+                                    value="email@mail.com"
+                                  >
+                                    <input
+                                      className="form-control"
+                                      disabled={false}
+                                      id="email"
+                                      name="email"
+                                      onBlur={[Function]}
+                                      onChange={[Function]}
+                                      onFocus={[Function]}
+                                      placeholder=""
+                                      type="email"
+                                      value="email@mail.com"
+                                    />
+                                  </FormControl>
+                                </div>
+                              </Col>
+                            </div>
+                          </FormGroup>
+                        </FinalFormComponent>
+                      </FinalFormField>
+                    </Field>
+                  </div>
+                </Col>
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                  xs={12}
+                >
+                  <div
+                    className="col-xs-12"
+                  >
+                    <Field
+                      component={[Function]}
+                      format={[Function]}
+                      label="Available Groups"
+                      multi={true}
+                      name="chosen_group"
+                      options={
+                        Array [
+                          Object {
+                            "label": "ckeller",
+                            "value": 10000000000029,
+                          },
+                          Object {
+                            "label": "Cloud-Operators",
+                            "value": 10000000000025,
+                          },
+                          Object {
+                            "label": "Cloud-Users",
+                            "value": 10000000000026,
+                          },
+                          Object {
+                            "label": "EvmGroup-administrator",
+                            "value": 10000000000005,
+                          },
+                          Object {
+                            "label": "EvmGroup-approver",
+                            "value": 10000000000006,
+                          },
+                          Object {
+                            "label": "EvmGroup-auditor",
+                            "value": 10000000000007,
+                          },
+                          Object {
+                            "label": "EvmGroup-consumption_administrator",
+                            "value": 10000000000016,
+                          },
+                          Object {
+                            "label": "EvmGroup-container_administrator",
+                            "value": 10000000000017,
+                          },
+                          Object {
+                            "label": "EvmGroup-container_operator",
+                            "value": 10000000000018,
+                          },
+                          Object {
+                            "label": "EvmGroup-desktop",
+                            "value": 10000000000011,
+                          },
+                          Object {
+                            "label": "EvmGroup-operator",
+                            "value": 10000000000003,
+                          },
+                          Object {
+                            "label": "EvmGroup-reader",
+                            "value": 10000000000036,
+                          },
+                          Object {
+                            "label": "EvmGroup-security",
+                            "value": 10000000000010,
+                          },
+                          Object {
+                            "label": "EvmGroup-super_administrator",
+                            "value": 10000000000002,
+                          },
+                          Object {
+                            "label": "EvmGroup-support",
+                            "value": 10000000000008,
+                          },
+                          Object {
+                            "label": "EvmGroup-tenant_administrator",
+                            "value": 10000000000014,
+                          },
+                          Object {
+                            "label": "EvmGroup-tenant_quota_administrator",
+                            "value": 10000000000015,
+                          },
+                          Object {
+                            "label": "EvmGroup-user",
+                            "value": 10000000000004,
+                          },
+                          Object {
+                            "label": "EvmGroup-user_limited_self_service",
+                            "value": 10000000000013,
+                          },
+                          Object {
+                            "label": "EvmGroup-user_self_service",
+                            "value": 10000000000012,
+                          },
+                          Object {
+                            "label": "EvmGroup-vm_user",
+                            "value": 10000000000009,
+                          },
+                          Object {
+                            "label": "loic Group",
+                            "value": 10000000000034,
+                          },
+                        ]
+                      }
+                      parse={[Function]}
+                      placeholder="Choose one or more Groups"
+                      validate={[Function]}
+                    >
+                      <FinalFormSelect
+                        input={
+                          Object {
+                            "name": "chosen_group",
+                            "onBlur": [Function],
+                            "onChange": [Function],
+                            "onFocus": [Function],
+                            "value": "",
+                          }
+                        }
+                        label="Available Groups"
+                        meta={
+                          Object {
+                            "active": false,
+                            "data": Object {},
+                            "dirty": false,
+                            "dirtySinceLastSubmit": false,
+                            "error": "A User must be assigned to a Group",
+                            "initial": undefined,
+                            "invalid": true,
+                            "pristine": true,
+                            "submitError": undefined,
+                            "submitFailed": false,
+                            "submitSucceeded": false,
+                            "touched": false,
+                            "valid": false,
+                            "visited": false,
+                          }
+                        }
+                        multi={true}
+                        options={
+                          Array [
+                            Object {
+                              "label": "ckeller",
+                              "value": 10000000000029,
+                            },
+                            Object {
+                              "label": "Cloud-Operators",
+                              "value": 10000000000025,
+                            },
+                            Object {
+                              "label": "Cloud-Users",
+                              "value": 10000000000026,
+                            },
+                            Object {
+                              "label": "EvmGroup-administrator",
+                              "value": 10000000000005,
+                            },
+                            Object {
+                              "label": "EvmGroup-approver",
+                              "value": 10000000000006,
+                            },
+                            Object {
+                              "label": "EvmGroup-auditor",
+                              "value": 10000000000007,
+                            },
+                            Object {
+                              "label": "EvmGroup-consumption_administrator",
+                              "value": 10000000000016,
+                            },
+                            Object {
+                              "label": "EvmGroup-container_administrator",
+                              "value": 10000000000017,
+                            },
+                            Object {
+                              "label": "EvmGroup-container_operator",
+                              "value": 10000000000018,
+                            },
+                            Object {
+                              "label": "EvmGroup-desktop",
+                              "value": 10000000000011,
+                            },
+                            Object {
+                              "label": "EvmGroup-operator",
+                              "value": 10000000000003,
+                            },
+                            Object {
+                              "label": "EvmGroup-reader",
+                              "value": 10000000000036,
+                            },
+                            Object {
+                              "label": "EvmGroup-security",
+                              "value": 10000000000010,
+                            },
+                            Object {
+                              "label": "EvmGroup-super_administrator",
+                              "value": 10000000000002,
+                            },
+                            Object {
+                              "label": "EvmGroup-support",
+                              "value": 10000000000008,
+                            },
+                            Object {
+                              "label": "EvmGroup-tenant_administrator",
+                              "value": 10000000000014,
+                            },
+                            Object {
+                              "label": "EvmGroup-tenant_quota_administrator",
+                              "value": 10000000000015,
+                            },
+                            Object {
+                              "label": "EvmGroup-user",
+                              "value": 10000000000004,
+                            },
+                            Object {
+                              "label": "EvmGroup-user_limited_self_service",
+                              "value": 10000000000013,
+                            },
+                            Object {
+                              "label": "EvmGroup-user_self_service",
+                              "value": 10000000000012,
+                            },
+                            Object {
+                              "label": "EvmGroup-vm_user",
+                              "value": 10000000000009,
+                            },
+                            Object {
+                              "label": "loic Group",
+                              "value": 10000000000034,
+                            },
+                          ]
+                        }
+                        placeholder="Choose one or more Groups"
+                      >
+                        <FinalFormComponent
+                          clearable={false}
+                          componentType="select"
+                          disabled={false}
+                          input={
+                            Object {
+                              "name": "chosen_group",
+                              "onBlur": [Function],
+                              "onChange": [Function],
+                              "onFocus": [Function],
+                              "value": "",
+                            }
+                          }
+                          inputColumnSize={8}
+                          label="Available Groups"
+                          labelColumnSize={2}
+                          labelKey="label"
+                          meta={
+                            Object {
+                              "active": false,
+                              "data": Object {},
+                              "dirty": false,
+                              "dirtySinceLastSubmit": false,
+                              "error": "A User must be assigned to a Group",
+                              "initial": undefined,
+                              "invalid": true,
+                              "pristine": true,
+                              "submitError": undefined,
+                              "submitFailed": false,
+                              "submitSucceeded": false,
+                              "touched": false,
+                              "valid": false,
+                              "visited": false,
+                            }
+                          }
+                          multi={true}
+                          options={
+                            Array [
+                              Object {
+                                "label": "ckeller",
+                                "value": 10000000000029,
+                              },
+                              Object {
+                                "label": "Cloud-Operators",
+                                "value": 10000000000025,
+                              },
+                              Object {
+                                "label": "Cloud-Users",
+                                "value": 10000000000026,
+                              },
+                              Object {
+                                "label": "EvmGroup-administrator",
+                                "value": 10000000000005,
+                              },
+                              Object {
+                                "label": "EvmGroup-approver",
+                                "value": 10000000000006,
+                              },
+                              Object {
+                                "label": "EvmGroup-auditor",
+                                "value": 10000000000007,
+                              },
+                              Object {
+                                "label": "EvmGroup-consumption_administrator",
+                                "value": 10000000000016,
+                              },
+                              Object {
+                                "label": "EvmGroup-container_administrator",
+                                "value": 10000000000017,
+                              },
+                              Object {
+                                "label": "EvmGroup-container_operator",
+                                "value": 10000000000018,
+                              },
+                              Object {
+                                "label": "EvmGroup-desktop",
+                                "value": 10000000000011,
+                              },
+                              Object {
+                                "label": "EvmGroup-operator",
+                                "value": 10000000000003,
+                              },
+                              Object {
+                                "label": "EvmGroup-reader",
+                                "value": 10000000000036,
+                              },
+                              Object {
+                                "label": "EvmGroup-security",
+                                "value": 10000000000010,
+                              },
+                              Object {
+                                "label": "EvmGroup-super_administrator",
+                                "value": 10000000000002,
+                              },
+                              Object {
+                                "label": "EvmGroup-support",
+                                "value": 10000000000008,
+                              },
+                              Object {
+                                "label": "EvmGroup-tenant_administrator",
+                                "value": 10000000000014,
+                              },
+                              Object {
+                                "label": "EvmGroup-tenant_quota_administrator",
+                                "value": 10000000000015,
+                              },
+                              Object {
+                                "label": "EvmGroup-user",
+                                "value": 10000000000004,
+                              },
+                              Object {
+                                "label": "EvmGroup-user_limited_self_service",
+                                "value": 10000000000013,
+                              },
+                              Object {
+                                "label": "EvmGroup-user_self_service",
+                                "value": 10000000000012,
+                              },
+                              Object {
+                                "label": "EvmGroup-vm_user",
+                                "value": 10000000000009,
+                              },
+                              Object {
+                                "label": "loic Group",
+                                "value": 10000000000034,
+                              },
+                            ]
+                          }
+                          placeholder="Choose one or more Groups"
+                          searchable={false}
+                          validateOnMount={false}
+                          valueKey="value"
+                        >
+                          <FormGroup
+                            bsClass="form-group"
+                            validationState={null}
+                          >
+                            <div
+                              className="form-group"
+                            >
+                              <Col
+                                bsClass="col"
+                                className="control-label"
+                                componentClass="label"
+                                xs={2}
+                              >
+                                <label
+                                  className="control-label col-xs-2"
+                                >
+                                  Available Groups
+                                </label>
+                              </Col>
+                              <Col
+                                bsClass="col"
+                                componentClass="div"
+                                xs={8}
+                              >
+                                <div
+                                  className="col-xs-8"
+                                >
+                                  <Select
+                                    arrowRenderer={[Function]}
+                                    autosize={true}
+                                    backspaceRemoves={true}
+                                    backspaceToRemoveMessage="Press backspace to remove {label}"
+                                    className=" final-form-select"
+                                    clearAllText="Clear all"
+                                    clearRenderer={[Function]}
+                                    clearValueText="Clear value"
+                                    clearable={false}
+                                    closeOnSelect={true}
+                                    deleteRemoves={true}
+                                    delimiter=","
+                                    disabled={false}
+                                    escapeClearsValue={true}
+                                    filterOptions={[Function]}
+                                    id="chosen_group"
+                                    ignoreAccents={true}
+                                    ignoreCase={true}
+                                    inputProps={Object {}}
+                                    isLoading={false}
+                                    joinValues={false}
+                                    label="Available Groups"
+                                    labelKey="label"
+                                    matchPos="any"
+                                    matchProp="any"
+                                    menuBuffer={0}
+                                    menuRenderer={[Function]}
+                                    multi={true}
+                                    name="chosen_group"
+                                    noResultsText="No results found"
+                                    onBlur={[Function]}
+                                    onBlurResetsInput={true}
+                                    onChange={[Function]}
+                                    onCloseResetsInput={true}
+                                    onFocus={[Function]}
+                                    onSelectResetsInput={true}
+                                    openOnClick={true}
+                                    optionClassName="final-form-select-option"
+                                    optionComponent={[Function]}
+                                    options={
+                                      Array [
+                                        Object {
+                                          "label": "ckeller",
+                                          "value": 10000000000029,
+                                        },
+                                        Object {
+                                          "label": "Cloud-Operators",
+                                          "value": 10000000000025,
+                                        },
+                                        Object {
+                                          "label": "Cloud-Users",
+                                          "value": 10000000000026,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-administrator",
+                                          "value": 10000000000005,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-approver",
+                                          "value": 10000000000006,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-auditor",
+                                          "value": 10000000000007,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-consumption_administrator",
+                                          "value": 10000000000016,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-container_administrator",
+                                          "value": 10000000000017,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-container_operator",
+                                          "value": 10000000000018,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-desktop",
+                                          "value": 10000000000011,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-operator",
+                                          "value": 10000000000003,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-reader",
+                                          "value": 10000000000036,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-security",
+                                          "value": 10000000000010,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-super_administrator",
+                                          "value": 10000000000002,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-support",
+                                          "value": 10000000000008,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-tenant_administrator",
+                                          "value": 10000000000014,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-tenant_quota_administrator",
+                                          "value": 10000000000015,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-user",
+                                          "value": 10000000000004,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-user_limited_self_service",
+                                          "value": 10000000000013,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-user_self_service",
+                                          "value": 10000000000012,
+                                        },
+                                        Object {
+                                          "label": "EvmGroup-vm_user",
+                                          "value": 10000000000009,
+                                        },
+                                        Object {
+                                          "label": "loic Group",
+                                          "value": 10000000000034,
+                                        },
+                                      ]
+                                    }
+                                    pageSize={5}
+                                    placeholder="Choose one or more Groups"
+                                    removeSelected={true}
+                                    required={false}
+                                    rtl={false}
+                                    scrollMenuIntoView={true}
+                                    searchable={false}
+                                    simpleValue={false}
+                                    tabSelectsValue={true}
+                                    trimFilter={true}
+                                    value=""
+                                    valueComponent={[Function]}
+                                    valueKey="value"
+                                  >
+                                    <div
+                                      className="Select  final-form-select Select--multi"
+                                    >
+                                      <div
+                                        className="Select-control"
+                                        onKeyDown={[Function]}
+                                        onMouseDown={[Function]}
+                                        onTouchEnd={[Function]}
+                                        onTouchMove={[Function]}
+                                        onTouchStart={[Function]}
+                                      >
+                                        <span
+                                          className="Select-multi-value-wrapper"
+                                          id="react-select-3--value"
+                                        >
+                                          <div
+                                            className="Select-placeholder"
+                                          >
+                                            Choose one or more Groups
+                                          </div>
+                                          <div
+                                            aria-activedescendant="react-select-3--value"
+                                            aria-disabled="false"
+                                            aria-expanded={false}
+                                            aria-owns=""
+                                            className="Select-input"
+                                            onBlur={[Function]}
+                                            onFocus={[Function]}
+                                            role="combobox"
+                                            style={
+                                              Object {
+                                                "border": 0,
+                                                "display": "inline-block",
+                                                "width": 1,
+                                              }
+                                            }
+                                            tabIndex={0}
+                                          />
+                                        </span>
+                                        <span
+                                          className="Select-arrow-zone"
+                                          onMouseDown={[Function]}
+                                        >
+                                          <span
+                                            className="Select-arrow"
+                                            onMouseDown={[Function]}
+                                          />
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </Select>
+                                </div>
+                              </Col>
+                            </div>
+                          </FormGroup>
+                        </FinalFormComponent>
+                      </FinalFormSelect>
+                    </Field>
+                  </div>
+                </Col>
+              </div>
+            </Row>
+            <Row
+              bsClass="row"
+              componentClass="div"
+            >
+              <div
+                className="row"
+              >
+                <Col
+                  bsClass="col"
+                  componentClass="div"
+                  xs={10}
+                >
+                  <div
+                    className="col-xs-10"
+                  >
+                    <ButtonGroup
+                      block={false}
+                      bsClass="btn-group"
+                      className="pull-right"
+                      justified={false}
+                      vertical={false}
+                    >
+                      <div
+                        className="pull-right btn-group"
+                      >
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
+                          bsStyle="primary"
+                          disabled={true}
+                          id="user-submit"
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <button
+                            className="btn btn-primary"
+                            disabled={true}
+                            id="user-submit"
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            Save
+                          </button>
+                        </Button>
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
+                          bsStyle="default"
+                          disabled={true}
+                          onClick={[Function]}
+                          type="button"
+                        >
+                          <button
+                            className="btn btn-default"
+                            disabled={true}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            Reset
                           </button>
                         </Button>
                         <Button

--- a/src/rbac-forms/tests/rbacUserForm.test.jsx
+++ b/src/rbac-forms/tests/rbacUserForm.test.jsx
@@ -8,6 +8,12 @@ import { RbacUserForm } from '../';
 
 describe('RbacUserForm component', () => {
   const initialProps = {};
+  const user = {
+    name: 'User name',
+    userid: 'User id',
+    email: 'email@mail.com',
+    group: [10000000000026, 10000000000016],
+  };
 
   beforeEach(() => {
     initialProps.groups = [
@@ -40,6 +46,11 @@ describe('RbacUserForm component', () => {
 
   it('Should render correctly', () => {
     const tree = mount(<RbacUserForm {...initialProps} />);
+    expect(toJson(tree)).toMatchSnapshot();
+  });
+
+  it('Should render editing version', () => {
+    const tree = mount(<RbacUserForm {...initialProps} initialValues={user} editEnabled />);
     expect(toJson(tree)).toMatchSnapshot();
   });
 
@@ -89,5 +100,21 @@ describe('RbacUserForm component', () => {
 
     wrapper.find('button#user-submit').simulate('click');
     expect(onSave).toHaveBeenCalled();
+  });
+
+  it('Should add input to change password and then hide', () => {
+    const wrapper = mount(<RbacUserForm {...initialProps} initialValues={user} editEnabled />);
+    const enabler = wrapper.find('#password-change-enabler');
+    let verify = wrapper.find('#password-verify');
+
+    expect(verify.length).toBe(0);
+    enabler.simulate('click');
+    verify = wrapper.find('#password-verify');
+    expect(verify).toBeTruthy();
+
+    const disabler = wrapper.find('#password-change-disabler');
+    disabler.simulate('click');
+    verify = wrapper.find('#password-verify');
+    expect(verify.length).toBe(0);
   });
 });

--- a/src/table/genericPreviewTable.jsx
+++ b/src/table/genericPreviewTable.jsx
@@ -97,9 +97,9 @@ class GenericPreviewTable extends Component {
     this.state.sortableColumnPropery === columnProps.column.property,
   );
 
-  handleSelected = ({ id }) => this.setState((prevState) => {
+  handleSelected = row => this.setState((prevState) => {
     const rows = prevState.rows.map((item) => {
-      if (item.id !== id) {
+      if (item[this.props.rowKey] !== row[this.props.rowKey]) {
         return item;
       }
       return {
@@ -123,6 +123,7 @@ class GenericPreviewTable extends Component {
   render() {
     const { PfProvider, Body, Header } = Table;
     const { rows, columns } = this.state;
+    const { rowKey } = this.props;
     return (
       <PfProvider
         striped
@@ -135,7 +136,7 @@ class GenericPreviewTable extends Component {
         <Header />
         <Body
           rows={[...rows]}
-          rowKey="id"
+          rowKey={rowKey}
           onRow={row => ({ onClick: () => this.props.rowClick(row) })}
         />
       </PfProvider>
@@ -183,26 +184,19 @@ GenericPreviewTable.propTypes = {
     property: PropTypes.string.isRequired,
     label: PropTypes.string.isRequired,
   })).isRequired,
-  rows: PropTypes.arrayOf(PropTypes.shape({
-    id: PropTypes.number.isRequired,
-    fullname: PropTypes.string.isRequired,
-    username: PropTypes.string.isRequired,
-    email: PropTypes.string,
-    currentgroup: PropTypes.string,
-    role: PropTypes.string,
-    lastlogon: PropTypes.string,
-    lastlogoff: PropTypes.string,
-  })).isRequired,
+  rows: PropTypes.array.isRequired,
   rowClick: PropTypes.func.isRequired,
   rowSelect: rowSelectProp,
   showSelect: PropTypes.bool,
   showIcon: PropTypes.bool,
   icon: tableIconProp,
+  rowKey: PropTypes.string,
 };
 
 GenericPreviewTable.defaultProps = {
   showSelect: false,
   showIcon: false,
+  rowKey: 'id',
 };
 
 export default GenericPreviewTable;

--- a/src/table/genericPreviewTable.jsx
+++ b/src/table/genericPreviewTable.jsx
@@ -13,6 +13,21 @@ class GenericPreviewTable extends Component {
       columns: this.createColumns(props.showIcon, props.showSelect, props.columns),
     };
   }
+
+  componentDidUpdate({ rows }) {
+    if (this.props.rows.length !== rows.length) {
+      this.setState((prevState) => { // eslint-disable-line
+        const { sortOrderAsc, sortableColumnPropery } = prevState;
+        return {
+          rows: this.state.sortableColumnPropery ?
+            this.props.rows.sort((a, b) =>
+              (sortOrderAsc ? a[sortableColumnPropery] > b[sortableColumnPropery] : a[sortableColumnPropery] < b[sortableColumnPropery])) :
+            this.props.rows,
+        };
+      });
+    }
+  }
+
   headerFormat = value => <Table.Heading>{value}</Table.Heading>;
   sortableHeaderFormat = (onSort, { column: { header: { label }, property } }, sortOrderAsc, isSorted) => (
     <Table.Heading

--- a/src/table/genericPreviewTable.jsx
+++ b/src/table/genericPreviewTable.jsx
@@ -113,16 +113,15 @@ class GenericPreviewTable extends Component {
   );
 
   handleSelected = row => this.setState((prevState) => {
+    let currentRow;
     const rows = prevState.rows.map((item) => {
       if (item[this.props.rowKey] !== row[this.props.rowKey]) {
         return item;
       }
-      return {
-        ...item,
-        selected: !item.selected,
-      };
+      currentRow = { ...item, selected: !item.selected };
+      return { ...currentRow };
     });
-    this.props.rowSelect(rows.filter(item => item.selected));
+    this.props.rowSelect(rows.filter(item => item.selected), currentRow);
     return { rows };
   })
 

--- a/src/vendor.js
+++ b/src/vendor.js
@@ -5,6 +5,7 @@ import * as React from 'react';
 import * as PFReact from 'patternfly-react';
 import * as ReactSelect from 'react-select';
 import * as PropTypes from 'prop-types';
+import * as ReactRouterDOM from 'react-router-dom';
 
 window.ReactSelect = ReactSelect;
 window.Redux = Redux;
@@ -13,3 +14,4 @@ window.ReactDOM = ReactDOM;
 window.React = React;
 window.PFReact = PFReact;
 window.PropTypes = PropTypes;
+window.ReactRouterDOM = ReactRouterDOM;


### PR DESCRIPTION
I have made some modifications to enable users editing via RbacUserForm.

I have also created a demo which includes all rbac components, that are needed for adding/viewing/editing users while using client-side redux routing. It should be reproducible in manageiq-ui-classic and with some API tuning we could replace bunch of old code.

Demo is using hashHistory, so it should not collide with any ruby routing.

Storybook for demo: https://5b34e0ddfdd72a0b134bf4fb--confident-banach-ee0a7a.netlify.com/?selectedKind=Rbac%20forms&selectedStory=Rbac%20complex%20demo&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Fstories%2Fstories-panel