### PR TITLE
Fix audit for 11th July 2018

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.1.0",
     "mini-css-extract-plugin": "^0.4.0",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.9.2",
     "react-router-dom": "^4.2.2",
     "redux-mock-store": "^1.5.1",
     "resolve-url-loader": "^2.2.1",


### PR DESCRIPTION
There were 5 moderate issues to be fixed by npm audit, all were resolved by running `npm audit fix` and it resulted into upping node-sass to version `^9.4.2` - [node-sass@v4.9.2](https://github.com/sass/node-sass/releases/tag/v4.9.2)