### PR TITLE
FinalFormSelect onChange event now returns only value from option.

### DIFF
--- a/src/forms/finalFormComponent.jsx
+++ b/src/forms/finalFormComponent.jsx
@@ -10,8 +10,9 @@ import './style.scss';
 const componentTypes = ['radio', 'checkbox', 'textarea', 'select', 'textfield', 'switch'];
 const switchComponents = ['radio', 'checkbox'];
 const inputTypes = ['text', 'email', 'number', 'password'];
-const selectValue = (option, labelKey) =>
-  option.sort((a, b) => (a[labelKey].toLowerCase() > b[labelKey].toLowerCase()));
+const selectValue = (option, labelKey, valueKey) =>
+  option.sort((a, b) => (a[labelKey].toLowerCase() > b[labelKey].toLowerCase()))
+    .map(item => item[valueKey]);
 
 const componentSelect = (componentType, { input, meta, ...rest }) => ({
   textfield: <FormControl type={rest.type || 'text'} {...input} placeholder={rest.placeholder} />,
@@ -22,7 +23,7 @@ const componentSelect = (componentType, { input, meta, ...rest }) => ({
     className={`${rest.invalid ? 'has-error' : ''} final-form-select`}
     optionClassName="final-form-select-option"
     {...input}
-    onChange={option => input.onChange(rest.multi ? selectValue(option, rest.labelKey) : option)}
+    onChange={option => input.onChange(rest.multi ? selectValue(option, rest.labelKey, rest.valueKey) : option[rest.valueKey])}
     {...rest}
   />,
   switch: <Switch {...input} value={!!input.value} onChange={(elem, state) => input.onChange(state)} {...rest} />,


### PR DESCRIPTION
Just a small change of selects. Not it will return only the actual value of selected option. This should make building forms a bit easier, because you only need values most of the time.

### Single select
`stateValue: { value: 55, label: 'Option label' }` => `stateValue: 55`
### Multi select
`stateValue: [{ value: 1, label: 'First option' }, { value: 2, label: 'Second option' }]` => `stateValue: [1, 2]`

Should not break any forms just yet.