### PR TITLE
Use something other than `about:blank` as testURL

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     ],
     "moduleNameMapper": {
       "\\.(css|scss)$": "identity-obj-proxy"
-    }
+    },
+    "testURL": "http://localhost"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
With this commit we prevent command

```
yarn test
```

from failing for all the tests with recent enough jest due to https://github.com/jsdom/jsdom/issues/2304. Problem is that Redux has some issues with `about:blank` address so everything explodes.

@miq-bot add_label enhancement
@miq-bot assign @Hyperkid123 