### PR TITLE
Add optional background for IconOrImage with a colored wrapper div

### DIFF
--- a/src/textual_summary/data/textual_summary.js
+++ b/src/textual_summary/data/textual_summary.js
@@ -13,7 +13,8 @@ export const summary1 = [
       {"label":"Security Groups","value":"18","icon":"pficon pficon-cloud-security","image":null,"link":"/ems_network/39?display=security_groups","title":"Show all Security Groups","hoverClass":""},
       {"label":"Floating IPs","value":"14","icon":"ff ff-floating-ip","image":null,"link":"/ems_network/39?display=floating_ips","title":"Show all Floating IPs","hoverClass":""},
       {"label":"Network Ports","value":"26","icon":"ff ff-network-port","image":null,"link":"/ems_network/39?display=network_ports","title":"Show all Network Ports","hoverClass":""},
-      {"label":"Load Balancers","value":"2","icon":"ff ff-load-balancer","image":null,"link":"/ems_network/39?display=load_balancers","title":"Show all Load Balancers","hoverClass":""}
+      {"label":"Load Balancers","value":"2","icon":"ff ff-load-balancer","image":null,"link":"/ems_network/39?display=load_balancers","title":"Show all Load Balancers","hoverClass":""},
+      {"label":"Power State","value":"On","icon":"fa fa-play","image":null,"hoverClass":"","background": "green"}
      ]
     },
     {"title":"Overview","component":"GenericGroup","items":[

--- a/src/textual_summary/generic_table_row.jsx
+++ b/src/textual_summary/generic_table_row.jsx
@@ -35,7 +35,7 @@ export default function GenericTableRow(props) {
     <tr onClick={e => props.onClick(item, e)} className={item.hoverClass} title={item.title}>
       <td className="label">{item.label}</td>
       <td>
-        <IconOrImage icon={item.icon} image={item.image} title={item.title} />
+        <IconOrImage icon={item.icon} image={item.image} title={item.title} background={item.background} />
         {value}
       </td>
     </tr>

--- a/src/textual_summary/icon_or_image.jsx
+++ b/src/textual_summary/icon_or_image.jsx
@@ -1,11 +1,22 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import './styles.scss';
 
 /**
  * Render icon or an image with a title
  */
 export default class IconOrImage extends React.Component {
-  renderIcon = () => <i className={this.props.icon} title={this.props.title} />;
+  renderIcon = () => {
+    if (this.props.background) {
+      return (
+        <div style={{ background: this.props.background }} className="backgrounded-icon">
+          <i className={this.props.icon} title={this.props.title} />
+        </div>
+      );
+    }
+
+    return <i className={this.props.icon} title={this.props.title} />;
+  };
 
   // FIXME: preprocess and test in-lined images
   renderImage = () => <img src={this.props.image} alt={this.props.title} title={this.props.title} />;
@@ -22,6 +33,7 @@ IconOrImage.propTypes = {
   title: PropTypes.string,
   image: PropTypes.string,
   icon: PropTypes.string,
+  background: PropTypes.string,
 };
 
 IconOrImage.defaultProps = {
@@ -29,4 +41,3 @@ IconOrImage.defaultProps = {
   image: null,
   icon: null,
 };
-

--- a/src/textual_summary/styles.scss
+++ b/src/textual_summary/styles.scss
@@ -1,0 +1,10 @@
+.backgrounded-icon {
+  display: inline-block;
+  height: 20px;
+  width: 20px;
+  text-align: center;
+  i {
+    align-self: center;
+    color: #fff;
+  }
+}

--- a/src/textual_summary/tests/__snapshots__/generic_group.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/generic_group.test.js.snap
@@ -55,6 +55,7 @@ exports[`GenericGroup renders just fine 1`] = `
           </td>
           <td>
             <IconOrImage
+              background={null}
               icon={null}
               image={null}
               title={null}
@@ -88,6 +89,7 @@ exports[`GenericGroup renders just fine 1`] = `
           </td>
           <td>
             <IconOrImage
+              background={null}
               icon={null}
               image={null}
               title={null}

--- a/src/textual_summary/tests/__snapshots__/generic_table_row.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/generic_table_row.test.js.snap
@@ -40,6 +40,7 @@ exports[`Simple Table renders multi-value just fine... 1`] = `
         </td>
         <td>
           <IconOrImage
+            background={null}
             icon={null}
             image="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
             title="Show Network Manager 'Amazon East Network Manager'"
@@ -71,6 +72,7 @@ exports[`Simple Table renders multi-value just fine... 1`] = `
                   }
                 >
                   <IconOrImage
+                    background={null}
                     icon={null}
                     image={null}
                     title="Amazon East Network Manager"
@@ -94,6 +96,7 @@ exports[`Simple Table renders multi-value just fine... 1`] = `
                   }
                 >
                   <IconOrImage
+                    background={null}
                     icon={null}
                     image={null}
                     title="Amazon West Network Manager"
@@ -139,6 +142,7 @@ exports[`Simple Table renders simple value just fine... 1`] = `
         </td>
         <td>
           <IconOrImage
+            background={null}
             icon={null}
             image="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
             title="Show Network Manager 'Amazon East Network Manager'"

--- a/src/textual_summary/tests/__snapshots__/icon_or_image.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/icon_or_image.test.js.snap
@@ -1,7 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Icon or Image renders icon with background 1`] = `
+<IconOrImage
+  background="blue"
+  icon="fa fa-foobar"
+  image={null}
+  title="foo bar title"
+>
+  <div
+    className="backgrounded-icon"
+    style={
+      Object {
+        "background": "blue",
+      }
+    }
+  >
+    <i
+      className="fa fa-foobar"
+      title="foo bar title"
+    />
+  </div>
+</IconOrImage>
+`;
+
 exports[`Icon or Image renders icon with title and alt if icon and no image are passed in 1`] = `
 <IconOrImage
+  background={null}
   icon="fa fa-foobar"
   image={null}
   title="foo bar title"
@@ -15,6 +39,7 @@ exports[`Icon or Image renders icon with title and alt if icon and no image are 
 
 exports[`Icon or Image renders image with title and alt if image is passed in 1`] = `
 <IconOrImage
+  background={null}
   icon={null}
   image="foo/bar.png"
   title="foo bar title"
@@ -29,6 +54,7 @@ exports[`Icon or Image renders image with title and alt if image is passed in 1`
 
 exports[`Icon or Image renders nothing if no icon and no image are passed in 1`] = `
 <IconOrImage
+  background={null}
   icon=""
   image={null}
   title="foo bar title"

--- a/src/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
@@ -291,6 +291,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -309,6 +310,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Aodh"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Aodh"
@@ -325,6 +327,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Aodh"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Aodh"
@@ -343,6 +346,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Aodh"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Aodh"
@@ -359,6 +363,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Aodh"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Aodh"
@@ -379,6 +384,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -397,6 +403,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Ceilometer"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Ceilometer"
@@ -413,6 +420,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Ceilometer"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Ceilometer"
@@ -431,6 +439,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Ceilometer"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Ceilometer"
@@ -447,6 +456,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Ceilometer"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Ceilometer"
@@ -467,6 +477,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -485,6 +496,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Cinder"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Cinder"
@@ -501,6 +513,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Cinder"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Cinder"
@@ -519,6 +532,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Cinder"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Cinder"
@@ -535,6 +549,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Cinder"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Cinder"
@@ -555,6 +570,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -573,6 +589,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Glance"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Glance"
@@ -589,6 +606,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Glance"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Glance"
@@ -607,6 +625,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Glance"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Glance"
@@ -623,6 +642,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Glance"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Glance"
@@ -643,6 +663,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -661,6 +682,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Gnocchi"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Gnocchi"
@@ -677,6 +699,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Gnocchi"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Gnocchi"
@@ -695,6 +718,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Gnocchi"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Gnocchi"
@@ -711,6 +735,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Gnocchi"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Gnocchi"
@@ -731,6 +756,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -749,6 +775,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Heat"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Heat"
@@ -765,6 +792,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Heat"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Heat"
@@ -783,6 +811,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Heat"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Heat"
@@ -799,6 +828,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Heat"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Heat"
@@ -819,6 +849,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -830,6 +861,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Keystone"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of running Keystone"
@@ -841,6 +873,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Keystone"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Keystone"
@@ -859,6 +892,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Keystone"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Keystone"
@@ -875,6 +909,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Keystone"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Keystone"
@@ -895,6 +930,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -913,6 +949,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Nova"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Nova"
@@ -929,6 +966,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Nova"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Nova"
@@ -947,6 +985,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Nova"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Nova"
@@ -963,6 +1002,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Nova"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Nova"
@@ -983,6 +1023,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           className="hover"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title={null}
@@ -1001,6 +1042,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of running Swift"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-ok"
             image={null}
             title="Show list of running Swift"
@@ -1017,6 +1059,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of failed Swift"
         >
           <IconOrImage
+            background={null}
             icon={null}
             image={null}
             title="Show list of failed Swift"
@@ -1035,6 +1078,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of all Swift"
         >
           <IconOrImage
+            background={null}
             icon="pficon pficon-service"
             image={null}
             title="Show list of all Swift"
@@ -1051,6 +1095,7 @@ exports[`MultilinkTable renders just fine 1`] = `
           title="Show list of configuration files of Swift"
         >
           <IconOrImage
+            background={null}
             icon="fa fa-file-o"
             image={null}
             title="Show list of configuration files of Swift"

--- a/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
@@ -59,6 +59,7 @@ exports[`TagGroup renders just fine 1`] = `
         </td>
         <td>
           <IconOrImage
+            background={null}
             icon="pficon pficon-zone"
             image={null}
             title={null}
@@ -82,6 +83,7 @@ exports[`TagGroup renders just fine 1`] = `
         </td>
         <td>
           <IconOrImage
+            background={null}
             icon="fa fa-tag"
             image={null}
             title={null}
@@ -103,6 +105,7 @@ exports[`TagGroup renders just fine 1`] = `
       >
         <td>
           <IconOrImage
+            background={null}
             icon="fa fa-tag"
             image={null}
             title={null}

--- a/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
@@ -138,6 +138,14 @@ exports[`TextualSummary renders just fine 1`] = `
               "title": "Show all Load Balancers",
               "value": "2",
             },
+            Object {
+              "background": "green",
+              "hoverClass": "",
+              "icon": "fa fa-play",
+              "image": null,
+              "label": "Power State",
+              "value": "On",
+            },
           ],
           "title": "Relationships",
         },
@@ -333,6 +341,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon={null}
                         image={null}
                         title={null}
@@ -366,6 +375,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon={null}
                         image={null}
                         title={null}
@@ -399,6 +409,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon={null}
                         image={null}
                         title={null}
@@ -531,6 +542,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon={null}
                         image={null}
                         title="Ok"
@@ -566,6 +578,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon={null}
                         image={null}
                         title="Ok"
@@ -608,6 +621,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon={null}
                         image={null}
                         title={null}
@@ -632,6 +646,7 @@ exports[`TextualSummary renders just fine 1`] = `
                               }
                             >
                               <IconOrImage
+                                background={null}
                                 icon={null}
                                 image={null}
                                 title={null}
@@ -654,6 +669,7 @@ exports[`TextualSummary renders just fine 1`] = `
                               }
                             >
                               <IconOrImage
+                                background={null}
                                 icon={null}
                                 image={null}
                                 title={null}
@@ -687,6 +703,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon={null}
                         image={null}
                         title={null}
@@ -779,6 +796,14 @@ exports[`TextualSummary renders just fine 1`] = `
                 "link": "/ems_network/39?display=load_balancers",
                 "title": "Show all Load Balancers",
                 "value": "2",
+              },
+              Object {
+                "background": "green",
+                "hoverClass": "",
+                "icon": "fa fa-play",
+                "image": null,
+                "label": "Power State",
+                "value": "On",
               },
             ],
             "title": "Relationships",
@@ -897,6 +922,14 @@ exports[`TextualSummary renders just fine 1`] = `
                   "title": "Show all Load Balancers",
                   "value": "2",
                 },
+                Object {
+                  "background": "green",
+                  "hoverClass": "",
+                  "icon": "fa fa-play",
+                  "image": null,
+                  "label": "Power State",
+                  "value": "On",
+                },
               ],
               "title": "Relationships",
             }
@@ -977,6 +1010,14 @@ exports[`TextualSummary renders just fine 1`] = `
                   "title": "Show all Load Balancers",
                   "value": "2",
                 },
+                Object {
+                  "background": "green",
+                  "hoverClass": "",
+                  "icon": "fa fa-play",
+                  "image": null,
+                  "label": "Power State",
+                  "value": "On",
+                },
               ]
             }
             onClick={[Function]}
@@ -1020,6 +1061,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="pficon pficon-cloud-tenant"
                         image={null}
                         title={null}
@@ -1063,6 +1105,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="ff ff-cloud-network"
                         image={null}
                         title="Show all Cloud Networks"
@@ -1106,6 +1149,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="pficon pficon-network"
                         image={null}
                         title="Show all Cloud Subnets"
@@ -1149,6 +1193,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="pficon pficon-route"
                         image={null}
                         title="Show all Network Routers"
@@ -1192,6 +1237,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="pficon pficon-cloud-security"
                         image={null}
                         title="Show all Security Groups"
@@ -1235,6 +1281,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="ff ff-floating-ip"
                         image={null}
                         title="Show all Floating IPs"
@@ -1278,6 +1325,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="ff ff-network-port"
                         image={null}
                         title="Show all Network Ports"
@@ -1321,6 +1369,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="ff ff-load-balancer"
                         image={null}
                         title="Show all Load Balancers"
@@ -1333,6 +1382,57 @@ exports[`TextualSummary renders just fine 1`] = `
                       <span>
                          
                         2
+                      </span>
+                    </td>
+                  </tr>
+                </GenericTableRow>
+                <GenericTableRow
+                  item={
+                    Object {
+                      "background": "green",
+                      "hoverClass": "",
+                      "icon": "fa fa-play",
+                      "image": null,
+                      "label": "Power State",
+                      "value": "On",
+                    }
+                  }
+                  key="8"
+                  onClick={[Function]}
+                >
+                  <tr
+                    className=""
+                    onClick={[Function]}
+                  >
+                    <td
+                      className="label"
+                    >
+                      Power State
+                    </td>
+                    <td>
+                      <IconOrImage
+                        background="green"
+                        icon="fa fa-play"
+                        image={null}
+                        title={null}
+                      >
+                        <div
+                          className="backgrounded-icon"
+                          style={
+                            Object {
+                              "background": "green",
+                            }
+                          }
+                        >
+                          <i
+                            className="fa fa-play"
+                            title={null}
+                          />
+                        </div>
+                      </IconOrImage>
+                      <span>
+                         
+                        On
                       </span>
                     </td>
                   </tr>
@@ -1414,6 +1514,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     </td>
                     <td>
                       <IconOrImage
+                        background={null}
                         icon="pficon pficon-topology"
                         image={null}
                         title="Show topology"
@@ -1500,6 +1601,7 @@ exports[`TextualSummary renders just fine 1`] = `
                   </td>
                   <td>
                     <IconOrImage
+                      background={null}
                       icon="pficon pficon-zone"
                       image={null}
                       title={null}
@@ -1522,6 +1624,7 @@ exports[`TextualSummary renders just fine 1`] = `
                   </td>
                   <td>
                     <IconOrImage
+                      background={null}
                       icon="fa fa-tag"
                       image={null}
                       title={null}

--- a/src/textual_summary/tests/icon_or_image.test.js
+++ b/src/textual_summary/tests/icon_or_image.test.js
@@ -18,4 +18,9 @@ describe('Icon or Image', () => {
     const image = mount(<IconOrImage icon="" title="foo bar title" />);
     expect(toJson(image)).toMatchSnapshot();
   });
+
+  it('renders icon with background', () => {
+    const image = mount(<IconOrImage icon="fa fa-foobar" title="foo bar title" background="blue" />)
+    expect(toJson(image)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This will allow us to display powerstate icons as a fonticon + background combo. If the background is set, a wrapper div with the `backgrounded-icon` class is being created. 

![screenshot from 2018-08-21 19-49-01](https://user-images.githubusercontent.com/649130/44419469-912ce880-a57b-11e8-8fe4-ed359f4a225d.png)

@miq-bot add_reviewer @epwinchell 
@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @martinpovolny 