### PR TITLE
Fix enable/disable buttons for rbac users form.

### DIFF
--- a/src/forms/finalFormComponent.jsx
+++ b/src/forms/finalFormComponent.jsx
@@ -11,8 +11,7 @@ const componentTypes = ['radio', 'checkbox', 'textarea', 'select', 'textfield', 
 const switchComponents = ['radio', 'checkbox'];
 const inputTypes = ['text', 'email', 'number', 'password'];
 const selectValue = (option, labelKey, valueKey) =>
-  option.sort((a, b) => (a[labelKey].toLowerCase() > b[labelKey].toLowerCase()))
-    .map(item => item[valueKey]);
+  option.sort((a, b) => a[labelKey].localeCompare(b[labelKey], 'en', { sensitivity: 'base' }).map(item => item[valueKey]));
 
 const componentSelect = (componentType, { input, meta, ...rest }) => ({
   textfield: <FormControl type={rest.type || 'text'} {...input} placeholder={rest.placeholder} />,

--- a/src/rbac-forms/rbacUserForm.jsx
+++ b/src/rbac-forms/rbacUserForm.jsx
@@ -31,82 +31,93 @@ const RbacUserForm = ({
     initialValues={initialValues}
     render={({
       invalid,
-      pristine,
       handleSubmit,
+      values,
       form: { change, reset },
-    }) => (
-      <PfForm horizontal>
-        <Grid fluid>
-          <Row>
-            <Col xs={12}>
-              <Field
-                name="name"
-                validate={required({ msg: __('Required') })}
-                component={FinalFormField}
-                label={__('Full Name')}
-                disabled={!newRecord && editDisabled}
+    }) => {
+      const pristine = JSON.stringify(initialValues) === JSON.stringify(values);
+      return (
+        <PfForm horizontal>
+          <Grid fluid>
+            <Row>
+              <Col xs={12}>
+                <Field
+                  name="name"
+                  validate={required({ msg: __('Required') })}
+                  component={FinalFormField}
+                  label={__('Full Name')}
+                  disabled={!newRecord && editDisabled}
+                />
+              </Col>
+              <Col xs={12}>
+                <Field
+                  name="userid"
+                  validate={required({ msg: __('Required') })}
+                  component={FinalFormField}
+                  label={__('Username')}
+                  disabled={!newRecord && editDisabled}
+                />
+              </Col>
+              <PasswordFragment
+                changeValue={change}
+                isEditing={!newRecord}
+                passwordValidators={[required({ msg: __('Required') })]}
               />
-            </Col>
-            <Col xs={12}>
-              <Field
-                name="userid"
-                validate={required({ msg: __('Required') })}
-                component={FinalFormField}
-                label={__('Username')}
-                disabled={!newRecord && editDisabled}
-              />
-            </Col>
-            <PasswordFragment
-              changeValue={change}
-              isEditing={!newRecord}
-              passwordValidators={[required({ msg: __('Required') })]}
-            />
-            <Col xs={12}>
-              <Field
-                name="email"
-                type="email"
-                validate={email({
+              <Col xs={12}>
+                <Field
+                  name="email"
+                  type="email"
+                  validate={email({
                   msg: __('Email must be a valid email address'),
                   allowBlank: true,
                 })}
-                component={FinalFormField}
-                label={__('Email Address')}
-              />
-            </Col>
-            <Col xs={12}>
-              <Field
-                name="groups"
-                validate={composeValidators(required({ msg: __('A User must be assigned to a Group') }), validateEmpty)}
-                component={FinalFormSelect}
-                label={__('Available Groups')}
-                options={groups}
-                placeholder={__('Choose one or more Groups')}
-                multi
-                searchable
-                clearable
-              />
-            </Col>
-          </Row>
-          <Row>
-            <Col xs={10}>
-              <ButtonGroup className="pull-right">
-                <Button
-                  id="user-submit"
-                  bsStyle="primary"
-                  disabled={pristine || invalid}
-                  type="button"
-                  onClick={handleSubmit}
-                >
-                  {newRecord ? __('Add') : __('Save')}
-                </Button>
-                {!newRecord && <Button disabled={pristine} onClick={reset} type="button">{__('Reset')}</Button>}
-                <Button onClick={onCancel}>{__('Cancel')}</Button>
-              </ButtonGroup>
-            </Col>
-          </Row>
-        </Grid>
-      </PfForm>
-    )}
+                  component={FinalFormField}
+                  label={__('Email Address')}
+                />
+              </Col>
+              <Col xs={12}>
+                <Field
+                  name="groups"
+                  validate={composeValidators(required({ msg: __('A User must be assigned to a Group') }), validateEmpty)}
+                  component={FinalFormSelect}
+                  label={__('Available Groups')}
+                  options={groups}
+                  placeholder={__('Choose one or more Groups')}
+                  multi
+                  searchable
+                  clearable
+                />
+              </Col>
+            </Row>
+            <Row>
+              <Col xs={10}>
+                <ButtonGroup className="pull-right">
+                  <Button
+                    id="user-submit"
+                    bsStyle="primary"
+                    disabled={pristine || invalid}
+                    type="button"
+                    onClick={handleSubmit}
+                  >
+                    {newRecord ? __('Add') : __('Save')}
+                  </Button>
+                  {!newRecord && (
+                  <Button
+                    disabled={pristine}
+                    onClick={reset}
+                    type="button"
+                  >
+                    {__('Reset')}
+                  </Button>
+                )}
+                  <Button onClick={onCancel}>{__('Cancel')}</Button>
+                </ButtonGroup>
+              </Col>
+            </Row>
+          </Grid>
+        </PfForm>
+    );
+}}
   />
 );
 

--- a/src/rbac-forms/stories/data.js
+++ b/src/rbac-forms/stories/data.js
@@ -1,42 +1,42 @@
 export const groups = [
   {
-    value: 1,
+    value: '1',
     label: 'Hope',
   },
   {
-    value: 2,
+    value: '2',
     label: 'Christa',
   },
   {
-    value: 3,
+    value: '3',
     label: 'Tania',
   },
   {
-    value: 4,
+    value: '4',
     label: 'Mcintyre',
   },
   {
-    value: 5,
+    value: '5',
     label: 'Tonya',
   },
   {
-    value: 6,
+    value: '6',
     label: 'Marcie',
   },
   {
-    value: 7,
+    value: '7',
     label: 'Cara',
   },
   {
-    value: 8,
+    value: '8',
     label: 'Becker',
   },
   {
-    value: 9,
+    value: '9',
     label: 'Foley',
   },
   {
-    value: 10,
+    value: '10',
     label: 'Perkins',
   },
 ];

--- a/src/rbac-forms/stories/rbacUserForm.stories.js
+++ b/src/rbac-forms/stories/rbacUserForm.stories.js
@@ -49,7 +49,7 @@ storiesOf('Rbac forms', module).add('Rbac add user form', withInfo()(() => (
       name: 'User name',
       userid: 'User id',
       email: 'email@mail.com',
-      groups: ['1', '2', '5'],
+      groups: ['2', '1', '5'],
     }}
   />
 )))

--- a/src/rbac-forms/tests/__snapshots__/rbacUserForm.test.jsx.snap
+++ b/src/rbac-forms/tests/__snapshots__/rbacUserForm.test.jsx.snap
@@ -1459,13 +1459,13 @@ exports[`RbacUserForm component Should render correctly 1`] = `
                           block={false}
                           bsClass="btn"
                           bsStyle="default"
-                          disabled={true}
+                          disabled={false}
                           onClick={[Function]}
                           type="button"
                         >
                           <button
                             className="btn btn-default"
-                            disabled={true}
+                            disabled={false}
                             onClick={[Function]}
                             type="button"
                           >


### PR DESCRIPTION
When editing some form and changing some values that are array or object and then changing then to match initial values, the pristine flag will be `false` even though it should be `true`.

React-final-form API is no making deep compassion, but there is an open PR that should fix it. See: https://github.com/final-form/react-final-form/issues/151

Until its fixed, i've added very simple compassion. 