### PR TITLE
Add extraProps attributes to form components.

### DIFF
--- a/src/forms/finalFormComponent.jsx
+++ b/src/forms/finalFormComponent.jsx
@@ -13,16 +13,22 @@ const switchComponents = ['radio', 'checkbox'];
 const inputTypes = ['text', 'email', 'number', 'password'];
 const selectValue = option => option.sort((a, b) => a.label.localeCompare(b.label, 'en', { sensitivity: 'base' })).map(item => item.value);
 
-const componentSelect = (componentType, { input, meta, ...rest }) => ({
-  textfield: <FormControl type={rest.type || 'text'} {...input} placeholder={rest.placeholder} />,
-  radio: <Radio {...input} >{rest.label}</Radio>,
-  checkbox: <Checkbox {...input}>{rest.label}</Checkbox>,
-  textarea: <FormControl componentClass="textarea" {...input} placeholder={rest.placeholder} />,
+const componentSelect = (componentType, {
+  input,
+  meta,
+  extraProps,
+  ...rest
+}) => ({
+  textfield: <FormControl type={rest.type || 'text'} {...input} placeholder={rest.placeholder} {...extraProps} />,
+  radio: <Radio {...extraProps} {...input} >{rest.label}</Radio>,
+  checkbox: <Checkbox {...extraProps} {...input}>{rest.label}</Checkbox>,
+  textarea: <FormControl {...extraProps} componentClass="textarea" {...input} placeholder={rest.placeholder} />,
   select: <ReactSelect
     className={`final-form-select ${meta.invalid ? 'has-error' : ''}`}
     styles={customStyles}
     {...input}
     {...rest}
+    {...extraProps}
     options={rest.options.filter(option => option.hasOwnProperty('value') && option.value !== null)} // eslint-disable-line
     value={rest.options.filter(({ value }) => (rest.multi ? input.value.includes(value) : value === input.value))}
     isMulti={rest.multi}
@@ -33,7 +39,7 @@ const componentSelect = (componentType, { input, meta, ...rest }) => ({
     noOptionsMessage={() => __('No option found')}
     onChange={option => input.onChange(rest.multi ? selectValue(option) : option && option.value)} // eslint-disable-line no-nested-ternary
   />,
-  switch: <Switch {...input} value={!!input.value} onChange={(elem, state) => input.onChange(state)} {...rest} />,
+  switch: <Switch {...input} {...extraProps} value={!!input.value} onChange={(elem, state) => input.onChange(state)} {...rest} />,
 })[componentType];
 
 const isSwitchInput = componentType => switchComponents.includes(componentType);
@@ -161,6 +167,7 @@ FinalFormComponent.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]),
+  extraProps: PropTypes.object,
 };
 
 FinalFormComponent.defaultProps = {
@@ -175,6 +182,7 @@ FinalFormComponent.defaultProps = {
   labelKey: 'label',
   valueKey: 'value',
   disabled: false,
+  extraProps: {},
 };
 
 export const FinalFormField = props => <FinalFormComponent componentType="textfield" {...props} />;

--- a/src/forms/tests/__snapshots__/fieldGroup.test.jsx.snap
+++ b/src/forms/tests/__snapshots__/fieldGroup.test.jsx.snap
@@ -90,6 +90,7 @@ exports[`Final form FieldGroup component Should render correctly 1`] = `
                     clearable={false}
                     componentType="radio"
                     disabled={false}
+                    extraProps={Object {}}
                     id="selectOne1"
                     input={
                       Object {
@@ -235,6 +236,7 @@ exports[`Final form FieldGroup component Should render correctly 1`] = `
                     clearable={false}
                     componentType="radio"
                     disabled={false}
+                    extraProps={Object {}}
                     id="selectOne2"
                     input={
                       Object {
@@ -462,6 +464,7 @@ exports[`Final form FieldGroup component Should render correctly with error stat
                     clearable={false}
                     componentType="radio"
                     disabled={false}
+                    extraProps={Object {}}
                     id="selectOne1"
                     input={
                       Object {
@@ -607,6 +610,7 @@ exports[`Final form FieldGroup component Should render correctly with error stat
                     clearable={false}
                     componentType="radio"
                     disabled={false}
+                    extraProps={Object {}}
                     id="selectOne2"
                     input={
                       Object {

--- a/src/forms/tests/finalFormField.test.jsx
+++ b/src/forms/tests/finalFormField.test.jsx
@@ -31,4 +31,22 @@ describe('Final form input component', () => {
     wrapper.find('input[type="text"]').simulate('change', { value: 'new value' });
     expect(onChange).toHaveBeenCalled();
   });
+
+  it('Should spread extraProps attributes to input', () => {
+    const props = {
+      ...initialProps,
+      extraProps: {
+        'data-cat': 'cat',
+        'data-dog': 'dog',
+        foo: 'bar',
+      },
+    };
+    const wrapper = mount(<FinalFormField {...props} />);
+    const input = wrapper.find('input');
+    expect(input.props()).toEqual(expect.objectContaining({
+      'data-dog': 'dog',
+      'data-cat': 'cat',
+      foo: 'bar',
+    }));
+  });
 });

--- a/src/vm-snapshot-form/snapshot-form/tests/__snapshots__/snapshotForm.test.jsx.snap
+++ b/src/vm-snapshot-form/snapshot-form/tests/__snapshots__/snapshotForm.test.jsx.snap
@@ -87,6 +87,7 @@ exports[`Final form input component Should render correctly 1`] = `
                       clearable={false}
                       componentType="textfield"
                       disabled={false}
+                      extraProps={Object {}}
                       input={
                         Object {
                           "name": "name",
@@ -239,6 +240,7 @@ exports[`Final form input component Should render correctly 1`] = `
                       clearable={false}
                       componentType="textarea"
                       disabled={false}
+                      extraProps={Object {}}
                       input={
                         Object {
                           "name": "description",
@@ -393,6 +395,7 @@ exports[`Final form input component Should render correctly 1`] = `
                       clearable={false}
                       componentType="switch"
                       disabled={false}
+                      extraProps={Object {}}
                       id="snap_memory"
                       input={
                         Object {
@@ -721,6 +724,7 @@ exports[`Final form input component Should render with description required 1`] 
                       clearable={false}
                       componentType="textfield"
                       disabled={false}
+                      extraProps={Object {}}
                       input={
                         Object {
                           "name": "name",
@@ -873,6 +877,7 @@ exports[`Final form input component Should render with description required 1`] 
                       clearable={false}
                       componentType="textarea"
                       disabled={false}
+                      extraProps={Object {}}
                       input={
                         Object {
                           "name": "description",
@@ -1036,6 +1041,7 @@ exports[`Final form input component Should render with description required 1`] 
                       clearable={false}
                       componentType="switch"
                       disabled={false}
+                      extraProps={Object {}}
                       id="snap_memory"
                       input={
                         Object {
@@ -1364,6 +1370,7 @@ exports[`Final form input component Should render with name required 1`] = `
                       clearable={false}
                       componentType="textfield"
                       disabled={false}
+                      extraProps={Object {}}
                       input={
                         Object {
                           "name": "name",
@@ -1525,6 +1532,7 @@ exports[`Final form input component Should render with name required 1`] = `
                       clearable={false}
                       componentType="textarea"
                       disabled={false}
+                      extraProps={Object {}}
                       input={
                         Object {
                           "name": "description",
@@ -1679,6 +1687,7 @@ exports[`Final form input component Should render with name required 1`] = `
                       clearable={false}
                       componentType="switch"
                       disabled={false}
+                      extraProps={Object {}}
                       id="snap_memory"
                       input={
                         Object {


### PR DESCRIPTION
I've started convert Report Editor into React and I want to do it gradually and for that I need to use original solution for sending form data for now. That's the reason why I need to pass data attributes to form components. 

I created a new prop called `data` which spreads all data attributes to input. I did not want pass every prop to inputs so that's why i created isolated prop. 