### PR TITLE
travis: Remove duplicate npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
   - node_modules
 
 script:
-- npm install
 - npm run build
 - npm run test-ci
 


### PR DESCRIPTION
Travis does `npm install` by default, because `npm` is set.
But then we do it again in `script`, and it doesn't do anything except spend 28 seconds rechecking.

=> removing :)