### PR TITLE
Storybook on surge - fix quadicons by copying assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
 - provider: script
   on:
     branch: master
-  script: npm run vendor && npm run build-storybook && ln -s ../public/assets ./.out/assets
+  script: npm run vendor && npm run build-storybook && cp -r ./public/assets ./.out/
   skip_cleanup: true
 - provider: surge
   on:


### PR DESCRIPTION
linking the files (added in https://github.com/ManageIQ/react-ui-components/pull/104) didn't work,
so this makes sure we copy the `assets` folder in the built storybook for deploy.

Hopefully, after merging this, http://react-ui-components.surge.sh/assets/manageiq.svg won't 404 anymore.