### PR TITLE
Use null instead of undefined as a blank Select value

### DIFF
--- a/src/tagging/components/InnerComponents/TagSelector.js
+++ b/src/tagging/components/InnerComponents/TagSelector.js
@@ -36,7 +36,7 @@ class TagSelector extends React.Component {
 
 
   render() {
-    const val = this.props.selectedOption.id ? { value: this.props.selectedOption.id, label: this.props.selectedOption.description } : undefined;
+    const val = this.props.selectedOption.id ? { value: this.props.selectedOption.id, label: this.props.selectedOption.description } : null;
     return (
       <Select
         value={val}

--- a/src/tagging/components/InnerComponents/ValueSelector.js
+++ b/src/tagging/components/InnerComponents/ValueSelector.js
@@ -31,7 +31,7 @@ class ValueSelector extends React.Component {
   );
 
   render() {
-    const val = this.props.selectedOption.id ? { value: this.props.selectedOption.id, label: this.props.selectedOption.description } : undefined;
+    const val = this.props.selectedOption.id ? { value: this.props.selectedOption.id, label: this.props.selectedOption.description } : null;
     return this.selector(
       val,
       this.getvalues(this.props.values),


### PR DESCRIPTION
Using `undefined` causes bug where `Select` remembered last value. Using null instead of undefined as should fix this issue.

@karelhala 