### PR TITLE
Pass options for MultiValueChange action

### DIFF
--- a/src/tagging/containers/tagging.js
+++ b/src/tagging/containers/tagging.js
@@ -24,8 +24,8 @@ const mapDispatchToProps = dispatch => ({
     dispatch(changeAssignedTag(val));
   },
 
-  onTagMultiValueChange: (val) => {
-    dispatch(toggleTagValueChange(val));
+  onTagMultiValueChange: (val, options) => {
+    dispatch(toggleTagValueChange(val, options));
     dispatch(addAssignedTag(val));
   },
 


### PR DESCRIPTION
Pass options for MultiValueChange action. 
I have introduced this in #105 to support middleware, but forgot to include also multiValueChange action.

@karelhala 