### PR TITLE
Replace deprecated @patternfly/patternfly-next with @patternfly/patternfly

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "webpack-dev-server": "^3.1.4"
   },
   "dependencies": {
-    "@patternfly/patternfly-next": "^1.0.42",
+    "@patternfly/patternfly": "^2.6.0",
     "@patternfly/react-core": "^1.11.1",
     "@patternfly/react-icons": "^2.4.0",
     "array-includes": "^3.0.3",

--- a/src/tagging-pf4/sass/_tag-category.scss
+++ b/src/tagging-pf4/sass/_tag-category.scss
@@ -1,4 +1,4 @@
-@import '~@patternfly/patternfly-next/sass-utilities/_all.scss';
+@import '~@patternfly/patternfly/sass-utilities/_all.scss';
 
 .pf4-tag-category.list-inline {
   background-color:$pf-color-blue-500;

--- a/src/tagging-pf4/sass/_tag.scss
+++ b/src/tagging-pf4/sass/_tag.scss
@@ -1,4 +1,4 @@
-@import '~@patternfly/patternfly-next/sass-utilities/_all.scss';
+@import '~@patternfly/patternfly/sass-utilities/_all.scss';
 
 :export { defaultColor: $pf-color-white; }
 


### PR DESCRIPTION
Same library, different name .. but updated the version to match UI classic.

(1.0.184 would also fix the BZ, but what's the point.)

---

Specifically, older version of patternfly introduce a class name clash between `pf-u*` styled by pf4, and `pf-utilization` by pf3. This was fixed to only use `pf-l-` and `pf-c-` prefixes (including a dash) in https://github.com/patternfly/patternfly-next/pull/1383.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1711913