### PR TITLE
Add react-select prefix for Tagging select

### DIFF
--- a/src/tagging/components/InnerComponents/TagSelector.js
+++ b/src/tagging/components/InnerComponents/TagSelector.js
@@ -48,6 +48,7 @@ class TagSelector extends React.Component {
         options={this.tagCategories}
         onChange={this.handleChange}
         name="form-field-name"
+        classNamePrefix="react-select"
         filterOption={(option, filter) =>
           option.data.keyWord.includes(filter.toLowerCase())
         }

--- a/src/tagging/components/InnerComponents/ValueSelector.js
+++ b/src/tagging/components/InnerComponents/ValueSelector.js
@@ -25,6 +25,7 @@ class ValueSelector extends React.Component {
       value={value}
       placeholder="Select tag value"
       onChange={this.handleChange}
+      classNamePrefix="react-select"
       options={values}
       clearable={false}
       ignoreCase

--- a/src/tagging/tests/__snapshots__/tag.selector.test.js.snap
+++ b/src/tagging/tests/__snapshots__/tag.selector.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Tagging modifier match snapshot 1`] = `
 <StateManager
   className="final-form-select"
+  classNamePrefix="react-select"
   clearable={false}
   defaultInputValue=""
   defaultMenuIsOpen={false}

--- a/src/tagging/tests/__snapshots__/value.selector.test.js.snap
+++ b/src/tagging/tests/__snapshots__/value.selector.test.js.snap
@@ -3,6 +3,7 @@
 exports[`match snapshot 1`] = `
 <StateManager
   className="final-form-select"
+  classNamePrefix="react-select"
   clearable={false}
   defaultInputValue=""
   defaultMenuIsOpen={false}
@@ -56,6 +57,7 @@ exports[`match snapshot 1`] = `
 exports[`match snapshot without multiple values 1`] = `
 <StateManager
   className="final-form-select"
+  classNamePrefix="react-select"
   clearable={false}
   defaultInputValue=""
   defaultMenuIsOpen={false}


### PR DESCRIPTION
Add react-select prefix for Tagging select, so now all div inside select component should have react-select prefix with `__` separator. For example: `react-select__value-container` or `react-select__control`
