### PR TITLE
Fix tagging select category styling

### DIFF
--- a/src/tagging/components/InnerComponents/TagSelector.js
+++ b/src/tagging/components/InnerComponents/TagSelector.js
@@ -16,7 +16,14 @@ class TagSelector extends React.Component {
 
   labelWithIcon = (description, infoText) => (
     <div>
-      <span>{description}</span>
+      <span
+        style={{
+          display: 'inline-block',
+          width: 'calc(100% - 18px)',
+        }}
+      >
+        {description}
+      </span>
       <span
         className="pull-right pficon pficon-info tag-icon"
         title={infoText}

--- a/src/tagging/stories/tagging.stories.js
+++ b/src/tagging/stories/tagging.stories.js
@@ -10,10 +10,10 @@ import taggingApp from '../reducers/';
 import { loadState } from '../actions';
 
 const tags = [
-  { description: 'Name', id: 1, singleValue: true, values: [{ description: 'Pepa', id: 11 }, { description: 'Franta', id: 12 }] },
-  { description: 'Number', id: 2, values: [{ description: '1', id: 21 }, { description: '2', id: 22 }] },
-  { description: 'Animal', id: 3, values: [{ description: 'Duck', id: 31 }, { description: 'Cat', id: 32 }, { description: 'Dog', id: 33 }] },
-  { description: 'Food', id: 4, values: [{ description: 'Steak', id: 41 }, { description: 'Duck', id: 42 }, { description: 'Salad', id: 43 }] },
+  { description: 'Name veryyyyyveryyyy loooong namee', id: 1, singleValue: true, values: [{ description: 'Pepa', id: 11 }, { description: 'Franta', id: 12 }] },
+  { description: 'Number xxx xxxxxxxxxxxx xxx xxxxxxxxx xxx', id: 2, singleValue: true, values: [{ description: '1', id: 21 }, { description: '2', id: 22 }] },
+  { description: 'Animal', id: 3, singleValue: true, values: [{ description: 'Duck', id: 31 }, { description: 'Cat', id: 32 }, { description: 'Dog', id: 33 }] },
+  { description: 'Food xxx xxxxxxxxxxxx xxx xxxxxxxxx xxx', id: 4,singleValue: true,  values: [{ description: 'Steak', id: 41 }, { description: 'Duck', id: 42 }, { description: 'Salad', id: 43 }] },
   {
     description: 'Something',
     id: 5,
@@ -22,7 +22,7 @@ const tags = [
   },
 ];
 const singleTags = [
-  { description: 'Name', id: 1, singleValue: true, values: [{ description: 'Pepa', id: 11 }, { description: 'Franta', id: 12 }] },
+  { description: 'Name veryyyyyveryyyy loooong nameeeeeeee', id: 1, singleValue: true, values: [{ description: 'Pepa', id: 11 }, { description: 'Franta', id: 12 }] },
   { description: 'Number', id: 2, singleValue: true, values: [{ description: '1', id: 21 }, { description: '2', id: 22 }] },
   { description: 'Animal', id: 3,singleValue: true, values: [{ description: 'Duck', id: 31 }, { description: 'Cat', id: 32 }, { description: 'Dog', id: 33 }] },
   { description: 'Food', id: 4, singleValue: true, values: [{ description: 'Steak', id: 41 }, { description: 'Duck', id: 42 }, { description: 'Salad', id: 43 }] },


### PR DESCRIPTION
When strings have "wrong" (not short, but not too long) length, styling of select is broken.

https://bugzilla.redhat.com/show_bug.cgi?id=1720094

Before:
![Selection_222](https://user-images.githubusercontent.com/9535558/59667814-a6809c80-91b7-11e9-8dc0-354c55710cf8.png)

After:
![Screenshot from 2019-06-18 10-55-05](https://user-images.githubusercontent.com/9535558/59667789-9963ad80-91b7-11e9-8ff4-54785b6c14f3.png)

@epwinchell please review