### PR TITLE
Edit TagGroup component to support onClick and displaying titles

### DIFF
--- a/src/textual_summary/data/tag_group.js
+++ b/src/textual_summary/data/tag_group.js
@@ -14,6 +14,15 @@ export const tagGroupData = {
       ],
       hoverClass: 'no-hover',
     },
+    {
+      label: 'Other Tags',
+      value: [
+        { icon: 'fa fa-tag', label: 'Test', value: ['Test 1'] },
+        { icon: 'fa fa-tag', label: 'Demo 2', value: ['Policy', '2', '3'] },
+        { value: ['Demo 3'], title: 'Click to display the item', link: 'You clicked on Demo 3' },
+      ],
+      title: 'All Other Tags',
+    },
   ],
   title: 'Smart Management',
 };

--- a/src/textual_summary/stories/TagGroup.stories.js
+++ b/src/textual_summary/stories/TagGroup.stories.js
@@ -6,6 +6,6 @@ import { tagGroupData } from '../data/tag_group';
 
 storiesOf('TextualSummary', module)
   .add('TagGroup', () => {
-    return (<TagGroup items={tagGroupData.items} title={tagGroupData.title} />);
+    return (<TagGroup items={tagGroupData.items} title={tagGroupData.title} onClick={(e) => console.log(e)} />);
   })
 ;

--- a/src/textual_summary/tag_group.jsx
+++ b/src/textual_summary/tag_group.jsx
@@ -7,29 +7,51 @@ import IconOrImage from './icon_or_image';
  */
 export default class TagGroup extends React.Component {
   /**
+   * Return onClick function if link is defined for an item/subitem
+   */
+  checkLinkItem = (item, e) => {
+    if (item.link && this.props.onClick) {
+      this.props.onClick(item, e);
+    }
+  }
+
+  /**
    * Render a simple row. Label, icon, value.
    */
   renderTagRowSimple = item => (
     <tr key={item.key}>
       <td className="label">{item.label}</td>
-      <td>
+      <td title={item.title} onClick={e => this.checkLinkItem(item, e)}>
         <IconOrImage icon={item.icon} image={item.image} title={item.title} />
+        {' '}
         {item.value}
       </td>
     </tr>
   );
 
   /**
-   * Render a list of values joined with "<b> | </b>"
+   * Render a list of values joined with "<b> | </b>", with or without label
    */
-  renderSubiteList = subitem => (
+  renderSubitemList = subitem => (
     <span>
-      {subitem.label}: {subitem.value.map((val, index) => (
+      &nbsp;
+      {subitem.label && `${subitem.label}: `}{Array.isArray(subitem.value) && subitem.value.map((val, index) => (
         <React.Fragment key={index}>
           {val}
           {(index < subitem.value.length - 1) && <b>&nbsp;|&nbsp;</b>}
         </React.Fragment>
-        ))}
+      ))}
+    </span>
+  );
+
+  /**
+   * Render a single value, with or without label
+   */
+  renderSubitem = subitem => (
+    <span>
+      &nbsp;
+      {subitem.label && `${subitem.label}: `}
+      {subitem.value}
     </span>
   );
 
@@ -46,11 +68,11 @@ export default class TagGroup extends React.Component {
       {item.value.map((subitem, index) => (
         <tr key={index}>
           {(index === 0) && (
-          <td rowSpan={item.value.length} className="label">{item.label}</td>
+          <td rowSpan={item.value.length} className="label" title={item.title}>{item.label}</td>
             )}
-          <td>
+          <td title={subitem.title} onClick={e => this.checkLinkItem(subitem, e)}>
             <IconOrImage icon={subitem.icon} image={subitem.image} text={subitem.text} />
-            {this.renderSubiteList(subitem)}
+            {Array.isArray(subitem.value) ? this.renderSubitemList(subitem) : this.renderSubitem(subitem)}
           </td>
         </tr>
         ))}
@@ -59,7 +81,7 @@ export default class TagGroup extends React.Component {
 
   render() {
     return (
-      <table className="table table-bordered table-striped table-summary-screen">
+      <table className="table table-bordered table-hover table-striped table-summary-screen">
         <thead>
           <tr>
             <th colSpan="2" align="left">{this.props.title}</th>
@@ -76,4 +98,5 @@ export default class TagGroup extends React.Component {
 TagGroup.propTypes = {
   title: PropTypes.string.isRequired,
   items: PropTypes.any.isRequired,
+  onClick: PropTypes.func,
 };

--- a/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
@@ -31,12 +31,41 @@ exports[`TagGroup renders just fine 1`] = `
           },
         ],
       },
+      Object {
+        "label": "Other Tags",
+        "title": "All Other Tags",
+        "value": Array [
+          Object {
+            "icon": "fa fa-tag",
+            "label": "Test",
+            "value": Array [
+              "Test 1",
+            ],
+          },
+          Object {
+            "icon": "fa fa-tag",
+            "label": "Demo 2",
+            "value": Array [
+              "Policy",
+              "2",
+              "3",
+            ],
+          },
+          Object {
+            "link": "You clicked on Demo 3",
+            "title": "Click to display the item",
+            "value": Array [
+              "Demo 3",
+            ],
+          },
+        ],
+      },
     ]
   }
   title="Smart Management"
 >
   <table
-    className="table table-bordered table-striped table-summary-screen"
+    className="table table-bordered table-hover table-striped table-summary-screen"
   >
     <thead>
       <tr>
@@ -57,7 +86,9 @@ exports[`TagGroup renders just fine 1`] = `
         >
           Managed by Zone
         </td>
-        <td>
+        <td
+          onClick={[Function]}
+        >
           <IconOrImage
             icon="pficon pficon-zone"
             image={null}
@@ -68,6 +99,7 @@ exports[`TagGroup renders just fine 1`] = `
               title={null}
             />
           </IconOrImage>
+           
           default
         </td>
       </tr>
@@ -80,7 +112,9 @@ exports[`TagGroup renders just fine 1`] = `
         >
           My Company X Tags
         </td>
-        <td>
+        <td
+          onClick={[Function]}
+        >
           <IconOrImage
             icon="fa fa-tag"
             image={null}
@@ -92,8 +126,8 @@ exports[`TagGroup renders just fine 1`] = `
             />
           </IconOrImage>
           <span>
-            Dan Test
-            : 
+             
+            Dan Test: 
             Test 1
           </span>
         </td>
@@ -101,7 +135,9 @@ exports[`TagGroup renders just fine 1`] = `
       <tr
         key="1"
       >
-        <td>
+        <td
+          onClick={[Function]}
+        >
           <IconOrImage
             icon="fa fa-tag"
             image={null}
@@ -113,13 +149,92 @@ exports[`TagGroup renders just fine 1`] = `
             />
           </IconOrImage>
           <span>
-            Demo bla
-            : 
+             
+            Demo bla: 
             Policy
             <b>
                | 
             </b>
             2
+          </span>
+        </td>
+      </tr>
+      <tr
+        key="0"
+      >
+        <td
+          className="label"
+          rowSpan={3}
+          title="All Other Tags"
+        >
+          Other Tags
+        </td>
+        <td
+          onClick={[Function]}
+        >
+          <IconOrImage
+            icon="fa fa-tag"
+            image={null}
+            title={null}
+          >
+            <i
+              className="fa fa-tag"
+              title={null}
+            />
+          </IconOrImage>
+          <span>
+             
+            Test: 
+            Test 1
+          </span>
+        </td>
+      </tr>
+      <tr
+        key="1"
+      >
+        <td
+          onClick={[Function]}
+        >
+          <IconOrImage
+            icon="fa fa-tag"
+            image={null}
+            title={null}
+          >
+            <i
+              className="fa fa-tag"
+              title={null}
+            />
+          </IconOrImage>
+          <span>
+             
+            Demo 2: 
+            Policy
+            <b>
+               | 
+            </b>
+            2
+            <b>
+               | 
+            </b>
+            3
+          </span>
+        </td>
+      </tr>
+      <tr
+        key="2"
+      >
+        <td
+          onClick={[Function]}
+          title="Click to display the item"
+        >
+          <IconOrImage
+            icon={null}
+            image={null}
+            title={null}
+          />
+          <span>
+             
+            Demo 3
           </span>
         </td>
       </tr>

--- a/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
@@ -1557,10 +1557,11 @@ exports[`TextualSummary renders just fine 1`] = `
                 },
               ]
             }
+            onClick={[Function]}
             title="Smart Management"
           >
             <table
-              className="table table-bordered table-striped table-summary-screen"
+              className="table table-bordered table-hover table-striped table-summary-screen"
             >
               <thead>
                 <tr>
@@ -1581,7 +1582,9 @@ exports[`TextualSummary renders just fine 1`] = `
                   >
                     Managed by Zone
                   </td>
-                  <td>
+                  <td
+                    onClick={[Function]}
+                  >
                     <IconOrImage
                       icon="pficon pficon-zone"
                       image={null}
@@ -1592,6 +1595,7 @@ exports[`TextualSummary renders just fine 1`] = `
                         title={null}
                       />
                     </IconOrImage>
+                     
                     Amazon Zone
                   </td>
                 </tr>
@@ -1603,7 +1607,9 @@ exports[`TextualSummary renders just fine 1`] = `
                   >
                     My Company Tags
                   </td>
-                  <td>
+                  <td
+                    onClick={[Function]}
+                  >
                     <IconOrImage
                       icon="fa fa-tag"
                       image={null}
@@ -1614,6 +1620,7 @@ exports[`TextualSummary renders just fine 1`] = `
                         title={null}
                       />
                     </IconOrImage>
+                     
                     No My Company Tags have been assigned
                   </td>
                 </tr>

--- a/src/textual_summary/textual_group.jsx
+++ b/src/textual_summary/textual_group.jsx
@@ -15,7 +15,7 @@ const renderComponent = (props) => {
         <GenericGroup onClick={props.onClick} items={props.group.items} title={props.group.title} />
       );
     case 'TagGroup':
-      return <TagGroup items={props.group.items} title={props.group.title} />;
+      return <TagGroup onClick={props.onClick} items={props.group.items} title={props.group.title} />;
     case 'SimpleTable':
       return (
         <SimpleTable


### PR DESCRIPTION
**What:**
Edit `TagGroup` component to support `onClick` and displaying titles (if they are specified).
Add some data for the appropriate storybook.

**Why:**
Needed for https://github.com/ManageIQ/manageiq-ui-classic/pull/5675

**Related RFE:**
https://bugzilla.redhat.com/show_bug.cgi?id=1678124

Some screenshots at:
https://github.com/ManageIQ/manageiq-ui-classic/pull/5675

