### PR TITLE
Set max width for tagging container

### DIFF
--- a/src/tagging/components/Tagging/Tagging.js
+++ b/src/tagging/components/Tagging/Tagging.js
@@ -47,7 +47,7 @@ class Tagging extends React.Component {
 
   render() {
     return (
-      <Grid>
+      <Grid fluid>
         <Row>
           <Col xs={12} md={8} lg={6}>
             <TagModifier hideHeader={this.props.options && this.props.options.hideHeaders}>

--- a/src/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
+++ b/src/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
@@ -12,7 +12,7 @@ class TaggingWithButtons extends React.Component {
 
   render() {
     return (
-      <Grid>
+      <Grid fluid>
         <Tagging
           tags={this.props.tags}
           assignedTags={this.props.assignedTags}

--- a/src/tagging/tests/__snapshots__/tagging.test.js.snap
+++ b/src/tagging/tests/__snapshots__/tagging.test.js.snap
@@ -4,7 +4,7 @@ exports[`Tagging component without redux mapping match snapshot 1`] = `
 <Grid
   bsClass="container"
   componentClass="div"
-  fluid={false}
+  fluid={true}
 >
   <Row
     bsClass="row"


### PR DESCRIPTION
In ManageIQ Tagging container is to wide, from buttons are out of the screen. In storybook it is not an issue, I think this is caused by merging PF4 styles, however I am not 100% sure.

Before:
![Screenshot from 2019-07-24 10-27-22](https://user-images.githubusercontent.com/9535558/61777817-e281cf80-adfd-11e9-98a8-487bdca8d368.png)

After:
![Screenshot from 2019-07-24 10-28-39](https://user-images.githubusercontent.com/9535558/61777827-e7df1a00-adfd-11e9-9a30-284fd40b6ff5.png)
