### PR TITLE
tagging - reduce tagging.js bundle size by not including react-bootstrap

### DIFF
--- a/src/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
+++ b/src/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid, Row, ButtonGroup, Button } from 'patternfly-react';
-import { ButtonToolbar } from 'react-bootstrap';
 import Tagging from '../Tagging/Tagging';
 import TaggingPropTypes from '../TaggingPropTypes';
 
@@ -26,7 +25,7 @@ class TaggingWithButtons extends React.Component {
           options={this.props.options}
         />
         <Row className="pull-right">
-          <ButtonToolbar>
+          <div role="toolbar" className="btn-toolbar">
             <ButtonGroup>
               <Button
                 onClick={() => this.props.saveButton.onClick(this.props.assignedTags)}
@@ -58,7 +57,7 @@ class TaggingWithButtons extends React.Component {
                 {this.props.cancelButton.description}
               </Button>
             </ButtonGroup>
-          </ButtonToolbar>
+          </div>
         </Row>
       </Grid>
     );


### PR DESCRIPTION
Problem (ui-classic, courtesy of webpack-bundle-analyzer):

![tagging bad](https://user-images.githubusercontent.com/289743/62462949-45695400-b778-11e9-9940-3ea9254ce8b1.png)

Running the same in react-ui-components:

![uir-tagging bad](https://user-images.githubusercontent.com/289743/62462965-4bf7cb80-b778-11e9-8588-7d55b8f6c600.png)


This is caused by including the whole of react-bootstrap in dist/tagging.js.
And we don't actually need it for a div with a role and a class, hence this PR :).

After:

![uir-tagging good](https://user-images.githubusercontent.com/289743/62462989-603bc880-b778-11e9-97d1-3d72310436e7.png)

And in storybook, it looks the same for both versions:

![after](https://user-images.githubusercontent.com/289743/62463008-6c278a80-b778-11e9-9ced-ae27817b675e.png)
