### PR TITLE
Drop ttembed-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,8 +134,7 @@
     "react-wooden-tree": "^2.0.1",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
-    "redux-mock-store": "^1.5.1",
-    "ttembed-js": "^0.1.1"
+    "redux-mock-store": "^1.5.1"
   },
   "release": {
     "analyzeCommits": "@khala/commit-analyzer-wildcard/analyzer",


### PR DESCRIPTION
[ttembed-js](https://www.npmjs.com/package/ttembed-js) comes from #79, but not used anymore,
and it depends on fs-ext 0.5.0, which is not compatible with node 12.

Thus, this should address https://github.com/ManageIQ/manageiq-ui-classic/issues/5589.

Cc @Hyperkid123 