### PR TITLE
React tree higlights node when it is dirty

### DIFF
--- a/src/wooden-tree/defaultStore.js
+++ b/src/wooden-tree/defaultStore.js
@@ -1,0 +1,45 @@
+import Tree, { ActionTypes } from './';
+
+const nodeCheckedWithDirty = (propNode, value) => {
+  let node = { ...propNode };
+  if (!node.state.disabled) {
+    if (!Object.hasOwnProperty.call(node.state, 'defaultChecked')) {
+      node = {
+        ...node,
+        state: {
+          ...node.state,
+          defaultChecked: node.state.checked,
+        },
+      };
+    }
+    node = {
+      ...Tree.nodeChecked(node, value),
+      classes: value !== node.state.defaultChecked ? 'dirty' : undefined,
+    };
+  }
+  return node;
+};
+
+const actionMapper = {
+  [ActionTypes.EXPANDED]: (state, value, node) => Tree.nodeUpdater(state, Tree.nodeExpanded(node, value)),
+  [ActionTypes.DISABLED]: (state, value, node) => Tree.nodeUpdater(state, Tree.nodeDisabled(node, value)),
+  [ActionTypes.SELECTED]: (state, value, node) => Tree.nodeUpdater(state, Tree.nodeSelected(node, value)),
+  [ActionTypes.CHILD_NODES]: (state, value, node) => Tree.nodeUpdater(state, Tree.nodeChildren(node, value)),
+  [ActionTypes.LOADING]: (state, value, node) => Tree.nodeUpdater(state, Tree.nodeLoading(node, value)),
+  [ActionTypes.CHECKED]: (state, value, node) => Tree.nodeUpdater(state, nodeCheckedWithDirty(node, value)),
+  [ActionTypes.ADD_NODES]: (state, value) => Tree.addNodes(state, value),
+};
+
+export default (state = {}, action) => {
+  let node;
+  if (action.nodeId) {
+    node = Tree.nodeSelector(state, action.nodeId);
+    if (!node) {
+      return state;
+    }
+  }
+
+  return Object.hasOwnProperty.call(actionMapper, action.type) ?
+    actionMapper[action.type](state, action.value, node) :
+    state;
+};

--- a/src/wooden-tree/index.scss
+++ b/src/wooden-tree/index.scss
@@ -6,4 +6,8 @@
   .NoOpenButton {
     margin-left: 1em;
   }
+
+  .dirty {
+    color: #39A5DC;
+  }
 }

--- a/src/wooden-tree/stories/reducers/index.js
+++ b/src/wooden-tree/stories/reducers/index.js
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import { treeDataReducer as treeData } from '../../';
+import { treeDataReducer as treeData } from './treeDataReducer';
 
 export const combinedReducers = combineReducers({ treeData });
 

--- a/src/wooden-tree/stories/reducers/treeDataReducer.js
+++ b/src/wooden-tree/stories/reducers/treeDataReducer.js
@@ -1,0 +1,3 @@
+import defaultStore from '../../defaultStore';
+
+export const treeDataReducer = defaultStore;


### PR DESCRIPTION
Added a modified store to the react tree wrapper which supports the highlighting of the nodes with changed (dirty) checkboxes. The highlight colour is [#39A5DC](https://github.com/jonmiles/bootstrap-treeview/pull/273).
**Before**
![Screenshot from 2019-09-09 15-45-25](https://user-images.githubusercontent.com/8531681/64536155-deabfd00-d318-11e9-9482-fa4c859fa014.png)

**After**
![Screenshot from 2019-09-09 15-44-19](https://user-images.githubusercontent.com/8531681/64536077-bde3a780-d318-11e9-9ed9-1d48d5687b57.png)

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6011

@skateman 
@karelhala 
@Hyperkid123 

