### PR TITLE
Fix dist/tagging.css

### DIFF
--- a/src/tagging/index.js
+++ b/src/tagging/index.js
@@ -1,6 +1,7 @@
 import taggingApp from './reducers';
 import { TaggingConnected, TaggingWithButtonsConnected } from './containers/tagging';
 import TagView from './components/InnerComponents/TagView';
+import './sass/style.scss';
 
 export { taggingApp, TaggingConnected, TaggingWithButtonsConnected, TagView };
 export * from './components/Tagging/Tagging';

--- a/src/tagging/sass/_tag-category.scss
+++ b/src/tagging/sass/_tag-category.scss
@@ -12,7 +12,7 @@
   display: -ms-flexbox;
   display: flex;
   -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
+  flex-wrap: wrap;
   float: left;
 
   li a span {

--- a/src/tagging/sass/_tag-category.scss
+++ b/src/tagging/sass/_tag-category.scss
@@ -1,0 +1,25 @@
+@import '~patternfly/dist/sass/patternfly/variables';
+
+.tag-category.list-inline {
+  background-color: $color-pf-blue-500;
+  padding: 3px 10px 3px 15px !important;
+  color: $color-pf-white;
+  margin-left: 5px;
+  margin-right: 10px;
+  margin-bottom: 5px;
+  font-size: 14px;
+  line-height: 24px;
+  display: -ms-flexbox;
+  display: flex;
+  -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+  float: left;
+
+  li a span {
+    color: $color-pf-white;
+  }
+}
+
+.category-label {
+  padding-right: 15px;
+}

--- a/src/tagging/sass/_tag-selector.scss
+++ b/src/tagging/sass/_tag-selector.scss
@@ -1,0 +1,17 @@
+.selected-option {
+  .Select-value {
+    width: calc(100% - 20px);
+
+    .pficon {
+      line-height: 34px !important;
+    }
+
+    .Select-value-label{
+      .tag-icon{display: none};
+    }
+  }
+}
+
+.tag-icon {
+  line-height: 18px;
+}

--- a/src/tagging/sass/_tag-selector.scss
+++ b/src/tagging/sass/_tag-selector.scss
@@ -1,19 +1,3 @@
-.selected-option {
-  .Select-value {
-    width: calc(100% - 20px);
-
-    .pficon {
-      line-height: 34px !important;
-    }
-
-    .Select-value-label {
-      .tag-icon {
-        display: none;
-      }
-    }
-  }
-}
-
 .tag-icon {
   line-height: 18px;
 }

--- a/src/tagging/sass/_tag-selector.scss
+++ b/src/tagging/sass/_tag-selector.scss
@@ -6,8 +6,10 @@
       line-height: 34px !important;
     }
 
-    .Select-value-label{
-      .tag-icon{display: none};
+    .Select-value-label {
+      .tag-icon {
+        display: none;
+      }
     }
   }
 }

--- a/src/tagging/sass/_tag.scss
+++ b/src/tagging/sass/_tag.scss
@@ -18,5 +18,5 @@
 }
 
 .tagColor {
-  color:$color-pf-white;
+  color: $color-pf-white;
 }

--- a/src/tagging/sass/_tag.scss
+++ b/src/tagging/sass/_tag.scss
@@ -1,0 +1,22 @@
+@import '~patternfly/dist/sass/patternfly/variables';
+:export { defaultColor: $color-pf-white; }
+
+.pf-remove-button {
+  color: $color-pf-white;
+  vertical-align: middle;
+  margin-left: 5px;
+}
+
+.tag {
+  font-size: 0.8em;
+  display: table-cell !important;
+  vertical-align:middle;
+
+  span {
+    background-color: $color-pf-blue-400;
+  }
+}
+
+.tagColor {
+  color:$color-pf-white;
+}

--- a/src/tagging/sass/style.scss
+++ b/src/tagging/sass/style.scss
@@ -1,4 +1,4 @@
 // Tag StyleSheets
-@import "tag-category";
-@import "tag-selector";
-@import "tag";
+@import "./tag-category";
+@import "./tag-selector";
+@import "./tag";

--- a/src/tagging/sass/style.scss
+++ b/src/tagging/sass/style.scss
@@ -1,0 +1,4 @@
+// Tag StyleSheets
+@import "tag-category";
+@import "tag-selector";
+@import "tag";

--- a/src/vendor.scss
+++ b/src/vendor.scss
@@ -11,4 +11,4 @@
 
 /* @import "~react-select/dist/react-select.css"; */
 
-@import "./tagging-pf4/sass/style";
+@import "./tagging/sass/style.scss";


### PR DESCRIPTION
This reverts a couple of deletions from #132 - cc @brumik 
Looks like all the styles contributing to `dist/tagging.css` were removed in c1a73f2, but looks like the intent was to only remove styles related to the old select, right?

And this mostly reverts #143, except for the linter fixes - cc @karelhala 
The idea is that this was right to fail, since the same issue caused ui-classic to fail as well.
So, reintroducing as a useful canary for next time :).

This means we should also be able to revert https://github.com/ManageIQ/manageiq-ui-classic/pull/6171 and just update to new react-ui-components, to get proper pf3 tagging styling back.

@miq-bot add_label wip
(this brings back all the styles, I *think* `tag-selector` should be the one to go, but want to make sure first)