### PR TITLE
Fixed console warning when using Tagging with buttons

### DIFF
--- a/src/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
+++ b/src/tagging/components/TaggingWithButtons/TaggingWithButtons.jsx
@@ -13,15 +13,13 @@ class TaggingWithButtons extends React.Component {
     return (
       <Grid fluid>
         <Tagging
+          selectedTagCategory={this.props.selectedTagCategory}
           tags={this.props.tags}
           assignedTags={this.props.assignedTags}
+          onTagDeleteClick={this.props.onTagDeleteClick}
+          onTagCategoryChange={this.props.onTagCategoryChange}
           onTagValueChange={this.props.onTagValueChange}
           onSingleTagValueChange={this.props.onSingleTagValueChange}
-          onTagMultiValueChange={this.props.onTagMultiValueChange}
-          onTagCategoryChange={this.props.onTagCategoryChange}
-          onTagDeleteClick={this.props.onTagDeleteClick}
-          selectedTagCategory={this.props.selectedTagCategory}
-          selectedTagValue={this.props.selectedTagValue}
           options={this.props.options}
         />
         <Row className="pull-right">
@@ -66,14 +64,12 @@ class TaggingWithButtons extends React.Component {
 
 TaggingWithButtons.propTypes = {
   selectedTagCategory: TaggingPropTypes.category,
-  selectedTagValue: TaggingPropTypes.value,
   tags: TaggingPropTypes.tags,
   assignedTags: TaggingPropTypes.tags,
   onTagDeleteClick: PropTypes.func.isRequired,
   onTagCategoryChange: PropTypes.func.isRequired,
   onTagValueChange: PropTypes.func.isRequired,
   onSingleTagValueChange: PropTypes.func,
-  onTagMultiValueChange: PropTypes.func,
   showReset: PropTypes.bool,
   cancelButton: TaggingPropTypes.button,
   resetButton: TaggingPropTypes.button,
@@ -87,7 +83,6 @@ TaggingWithButtons.propTypes = {
 TaggingWithButtons.defaultProps = {
   showReset: true,
   onSingleTagValueChange: () => {},
-  onTagMultiValueChange: () => {},
 };
 
 export default TaggingWithButtons;


### PR DESCRIPTION
Updating the component previously forget to update the props definitions in the `TaggingWithButtons` component, so there was a warning about the unused props that they are required (they were not passed to the component).

@miq-bot add_label react, bug
@miq-bot add_reviewer @karelhala
@miq-bot add_reviewer @PanSpagetka 

Closes #146