### PR TITLE
Tree View component now expands/collapses if is not selectable

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-final-form": "^4.1.0",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.0.1",
+    "react-wooden-tree": "^2.0.2",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"

--- a/src/wooden-tree/stories/Generator.js
+++ b/src/wooden-tree/stories/Generator.js
@@ -58,7 +58,21 @@ export function generator() {
         {
           text: 'Child 4 - Changed background color - with transparency',
           icon: 'fa fa-circle',
-          iconBackground: 'rgba(0,0,0,0.5',
+          iconBackground: 'rgba(0,0,0,0.5)',
+        },
+      ],
+    },
+    {
+      text: 'Parent 5 - Not selectabe with children (click on text triggers expand/collapse)',
+      selectable: false,
+      nodes: [
+        {
+          text: 'Child 1 - Changed icon color',
+          icon: 'fa fa-circle ',
+        },
+        {
+          text: 'Child 2 - Changed background color',
+          icon: 'fa fa-circle',
         },
       ],
     },


### PR DESCRIPTION
Tree View component now expands/collapses if it's not selectable and clicked.

Updated the version of the tree view since it supports this functionality added an example of it's working.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/6010

@miq-bot add_label bug
@miq-bot add_reviewer @skateman 
@miq-bot add_reviewer @karelhala  