### PR TITLE
Allow empty sotre for the redux tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-final-form": "^4.1.0",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.0.2",
+    "react-wooden-tree": "^2.0.3",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"

--- a/src/wooden-tree/defaultStore.js
+++ b/src/wooden-tree/defaultStore.js
@@ -34,9 +34,6 @@ export default (state = {}, action) => {
   let node;
   if (action.nodeId) {
     node = Tree.nodeSelector(state, action.nodeId);
-    if (!node) {
-      return state;
-    }
   }
 
   return Object.hasOwnProperty.call(actionMapper, action.type) ?

--- a/src/wooden-tree/stories/WoodenTree.stories.js
+++ b/src/wooden-tree/stories/WoodenTree.stories.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { Provider, connect } from 'react-redux';
 import { createStore } from 'redux';
 import { storiesOf } from '@storybook/react';
-import Tree, { callBack } from '../';
+import Tree, { callBack, ActionTypes } from '../';
 import { generator, flatLazyChildren } from './Generator';
 import { ReduxTree } from './components/ReduxTree';
 import { ConnectedNode } from './components/ReduxNode';
@@ -11,9 +12,16 @@ import combinedReducers from './reducers';
 /** Create the tree from hierarchical data */
 const tree = Tree.convertHierarchicalTree(Tree.initHierarchicalTree(generator()));
 /** The store */
-const store = createStore(combinedReducers, { treeData: tree });
+const store = createStore(combinedReducers);
 
 class App extends React.Component {
+  /**
+   * Initialize the tree after the component mounted.
+   */
+  componentDidMount() {
+    this.props.callBack(null, ActionTypes.ADD_NODES, tree);
+  }
+
   /**
    * On data change this function is called. In this example it is just
    * dispatches redux event (and for demo app purposes logs the dispatched event).
@@ -65,6 +73,10 @@ class App extends React.Component {
     );
   }
 }
+
+App.propTypes = {
+  callBack: PropTypes.func.isRequired,
+};
 
 const WoodenTreeExample = connect(null, { callBack })(App);
 


### PR DESCRIPTION
The tree view needed the redux store to be initialized with a non-null or empty data to work. Otherwise, it threw an error about reading a property of an undefined object.

The react-wooden-tree component was updated externally. Now it is possible to insert data later into the redux store. The storybook was updated to show this possibility.

Connects to #150

@miq-bot add_reviewer @Hyperkid123 
@miq-bot add_reviewer @karelhala 
@miq-bot add_reviewer @skateman 