### PR TITLE
Toolbar click close fix

### DIFF
--- a/src/toolbar/ToolbarKebab.jsx
+++ b/src/toolbar/ToolbarKebab.jsx
@@ -21,9 +21,7 @@ const ToolbarSubmenu = props => (
     onItemClick={() => props.setIsOpenId(props.id)}
     onToggle={() => null}
     open={props.openId === props.id}
-    // eslint-disable-next-line react/prop-types
     onSelect={props.onSelect}
-    // eslint-disable-next-line react/prop-types
     onKeyDown={props.onKeyDown}
   >
     { props.items.filter(i => !i.hidden).map(i => (
@@ -48,7 +46,15 @@ ToolbarSubmenu.propTypes = {
   onClick: PropTypes.func.isRequired,
   openId: PropTypes.string,
   setIsOpenId: PropTypes.func.isRequired,
+  onSelect: PropTypes.func,
+  onKeyDown: PropTypes.func,
 };
+
+ToolbarSubmenu.defaultProps = {
+  onSelect: null,
+  onKeyDown: null,
+};
+
 
 const KebabListItem = (item, props, openId, setIsOpenId) => {
   if (item.type === 'separator') {

--- a/src/toolbar/ToolbarKebab.jsx
+++ b/src/toolbar/ToolbarKebab.jsx
@@ -21,6 +21,10 @@ const ToolbarSubmenu = props => (
     onItemClick={() => props.setIsOpenId(props.id)}
     onToggle={() => null}
     open={props.openId === props.id}
+    // eslint-disable-next-line react/prop-types
+    onSelect={props.onSelect}
+    // eslint-disable-next-line react/prop-types
+    onKeyDown={props.onKeyDown}
   >
     { props.items.filter(i => !i.hidden).map(i => (
       <MenuItem
@@ -46,17 +50,21 @@ ToolbarSubmenu.propTypes = {
   setIsOpenId: PropTypes.func.isRequired,
 };
 
-const KebabListItem = (item, onClick, openId, setIsOpenId) => {
+const KebabListItem = (item, props, openId, setIsOpenId) => {
   if (item.type === 'separator') {
     return <MenuItem key={item.id} disabled={!item.enabled} eventKey={item.id} divider />;
   }
 
   if (item.type === 'buttonSelect') {
-    return <ToolbarSubmenu key={item.id} {...item} onClick={onClick} openId={openId} setIsOpenId={setIsOpenId} />;
+    // eslint-disable-next-line react/prop-types
+    return <ToolbarSubmenu key={item.id} {...item} onClick={props.onClick} openId={openId} setIsOpenId={setIsOpenId} />;
   }
 
   return (
-    <MenuItem disabled={!item.enabled} eventKey={item.id} >
+    <MenuItem
+      disabled={!item.enabled}
+      eventKey={item.id}
+    >
       <ToolbarClick key={item.id} {...item} />
     </MenuItem>
   );
@@ -68,7 +76,7 @@ export const ToolbarKebab = (props) => {
   return (
     <div className="kebab">
       <DropdownButton onClick={() => setIsOpenId(undefined)} id="menu_kebab" title={<span className="fa fa-ellipsis-v" />}>
-        {props.items.map(item => KebabListItem(item, props.onClick, openId, setIsOpenId))}
+        {props.items.map(item => KebabListItem(item, props, openId, setIsOpenId))}
       </DropdownButton>
     </div>
   );
@@ -76,7 +84,8 @@ export const ToolbarKebab = (props) => {
 
 ToolbarKebab.propTypes = {
   items: PropTypes.arrayOf(PropTypes.any),
-  onClick: PropTypes.func.isRequired,
+  // eslint-disable-next-line react/no-unused-prop-types
+  onClick: PropTypes.func.isRequired, // this really IS required
 };
 
 export default ToolbarKebab;

--- a/src/toolbar/ToolbarListItem.jsx
+++ b/src/toolbar/ToolbarListItem.jsx
@@ -11,9 +11,7 @@ export const ToolbarListItem = props => (
       disabled={!props.enabled}
       eventKey={props.id}
       onClick={props.onClick && props.enabled ? (() => props.onClick(props)) : null}
-      // eslint-disable-next-line react/prop-types
       onSelect={props.onSelect}
-      // eslint-disable-next-line react/prop-types
       onKeyDown={props.onKeyDown}
     >
       <ToolbarClick {...props} />
@@ -25,4 +23,11 @@ ToolbarListItem.propTypes = {
   enabled: PropTypes.bool,
   type: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
+  onSelect: PropTypes.func,
+  onKeyDown: PropTypes.func,
+};
+
+ToolbarListItem.defaultProps = {
+  onSelect: null,
+  onKeyDown: null,
 };

--- a/src/toolbar/ToolbarListItem.jsx
+++ b/src/toolbar/ToolbarListItem.jsx
@@ -11,6 +11,10 @@ export const ToolbarListItem = props => (
       disabled={!props.enabled}
       eventKey={props.id}
       onClick={props.onClick && props.enabled ? (() => props.onClick(props)) : null}
+      // eslint-disable-next-line react/prop-types
+      onSelect={props.onSelect}
+      // eslint-disable-next-line react/prop-types
+      onKeyDown={props.onKeyDown}
     >
       <ToolbarClick {...props} />
     </MenuItem>


### PR DESCRIPTION
Toolbar: pass onSelect and onKeyDown for drop-downs to properly close.

To be rebased after https://github.com/ManageIQ/react-ui-components/pull/155 is merged.

This makes also the keyboard work in the drop-downs. Meaning keyboard works everywhere except for the Kebab menu. Dealing with the Kebab menu is not part of this PR.