### PR TITLE
Toolbar tag fix

### DIFF
--- a/src/toolbar/Toolbar.jsx
+++ b/src/toolbar/Toolbar.jsx
@@ -73,9 +73,9 @@ export const ToolbarGroup = ({ group, onClick }) => {
   }
 
   return (
-    <span className="miq-toolbar-group form-group">
+    <div className="miq-toolbar-group form-group">
       {visibleItems.map((i, index) => buttonCase(i, index, onClick))}
-    </span>
+    </div>
   );
 };
 

--- a/src/toolbar/stories/Toolbar.stories.js
+++ b/src/toolbar/stories/Toolbar.stories.js
@@ -11,24 +11,28 @@ const toolbarBigData = require('../data/toolbar-big.json');
 storiesOf('Toolbar', module)
   .add('Toolbar', () => (
     <React.Fragment>
-      <div style={{ padding: 16 }}>
+      <div className="container-fluid">
         <div className="toolbar-pf row">
-          <Toolbar
-            onClick={action('Toolbar click')}
-            onViewClick={action('Toolbar click')}
-            groups={toolbarData}
-            views={viewData}
-          />
+          <div className="col-sm-12">
+            <Toolbar
+              onClick={action('Toolbar click')}
+              onViewClick={action('Toolbar click')}
+              groups={toolbarData}
+              views={viewData}
+            />
+          </div>
         </div>
       </div>
-      <div style={{ padding: 16 }}>
+      <div className="container-fluid">
         <div className="toolbar-pf row">
-          <Toolbar
-            onClick={action('Toolbar click')}
-            onViewClick={action('Toolbar click')}
-            groups={toolbarBigData}
-            views={viewData}
-          />
+          <div className="col-sm-12">
+            <Toolbar
+              onClick={action('Toolbar click')}
+              onViewClick={action('Toolbar click')}
+              groups={toolbarBigData}
+              views={viewData}
+            />
+          </div>
         </div>
       </div>
     </React.Fragment>

--- a/src/toolbar/styles.scss
+++ b/src/toolbar/styles.scss
@@ -18,13 +18,9 @@
   }
 }
 
-// copied: ui-components/src/styles/ui-components.scss
-// overrides _toolbar.scss to account for intermediate Angular markup and adjusted the margins to properly style wrapped form-groups
 .miq-toolbar-actions {
   margin-top: -10px;
-  .form-group:first-of-type {
-    padding-left: 0;
-  }
+  margin-left: -20px;  /* this compensates for toolbar-pf-filter not being in the first position */
   .form-group {
     margin-top: 10px;
     padding-left: 20px;


### PR DESCRIPTION
This PR replaces the form-group span tag with the expected div tag, fixing an issue where the vertical space between the breadcrumbs and toolbar collapsed at the mobile/tablet breakpoint in ui-classic. It also adjusts the css to properly left-align the button groups for small screens. The demo page is also updated.

Issue: https://github.com/ManageIQ/manageiq-ui-classic/issues/6317

Before:
<img width="724" alt="Screen Shot 2019-10-25 at 12 13 16 PM" src="https://user-images.githubusercontent.com/1287144/67586975-da993a80-f720-11e9-8265-417347cad24a.png">

After:
<img width="725" alt="Screen Shot 2019-10-25 at 11 51 27 AM" src="https://user-images.githubusercontent.com/1287144/67585572-d3246200-f71d-11e9-997d-ac92358a4f3f.png">

Before (Demo):
<img width="623" alt="Screen Shot 2019-10-25 at 2 12 02 PM" src="https://user-images.githubusercontent.com/1287144/67594053-82b6ff80-f731-11e9-8b58-d2c7c9300f09.png">

After (Demo):
<img width="676" alt="Screen Shot 2019-10-25 at 2 10 01 PM" src="https://user-images.githubusercontent.com/1287144/67593896-2bb12a80-f731-11e9-9798-05901df07043.png">

