### PR TITLE
View button responsiveness fix

### DIFF
--- a/src/toolbar/ToolbarView.jsx
+++ b/src/toolbar/ToolbarView.jsx
@@ -5,25 +5,27 @@ import { adjustColor } from './utility';
 const classNames = require('classnames');
 
 export const ToolbarView = ({ views, onClick }) => (
-  <div className="toolbar-pf-view-selector pull-right form-group">
-    {views.map(view => (
-      <button
-        key={view.id}
-        id={view.id}
-        name={view.name}
-        title={view.title}
-        className={classNames('btn btn-link', { active: view.selected })}
-        data-url={view.url}
-        data-url_parms={view.url_parms}
-        data-send_checked={view.send_checked ? 'true' : ''}
-        data-prompt={view.prompt}
-        data-popup={view.popup}
-        onClick={() => onClick(view)}
-      >
-        <i className={view.icon} style={{ color: adjustColor(view.color, view.enabled) }} />
-      </button>
-      ))
-    }
+  <div className="toolbar-pf-action-right">
+    <div className="form-group toolbar-pf-view-selector">
+      {views.map(view => (
+        <button
+          key={view.id}
+          id={view.id}
+          name={view.name}
+          title={view.title}
+          className={classNames('btn btn-link', { active: view.selected })}
+          data-url={view.url}
+          data-url_parms={view.url_parms}
+          data-send_checked={view.send_checked ? 'true' : ''}
+          data-prompt={view.prompt}
+          data-popup={view.popup}
+          onClick={() => onClick(view)}
+        >
+          <i className={view.icon} style={{ color: adjustColor(view.color, view.enabled) }} />
+        </button>
+        ))
+      }
+    </div>
   </div>
 );
 


### PR DESCRIPTION
The PR adds in the missing "toolbar-pf-action-right" class div, which makes the view buttons align left when in the responsive state.

Before (demo)
<img width="729" alt="Screen Shot 2019-10-29 at 11 35 43 AM" src="https://user-images.githubusercontent.com/1287144/67783211-50164b00-fa40-11e9-9554-6cf463f310bc.png">

After (demo)
<img width="736" alt="Screen Shot 2019-10-29 at 11 29 29 AM" src="https://user-images.githubusercontent.com/1287144/67782961-e4cc7900-fa3f-11e9-8294-6d1271695577.png">

Before (ui classic)
<img width="725" alt="Screen Shot 2019-10-29 at 11 34 25 AM" src="https://user-images.githubusercontent.com/1287144/67783120-278e5100-fa40-11e9-8bc1-42526a7c4122.png">

After (ui classic)
<img width="746" alt="Screen Shot 2019-10-29 at 11 30 44 AM" src="https://user-images.githubusercontent.com/1287144/67782962-e4cc7900-fa3f-11e9-8558-9917a545b6b0.png">
