### PR TITLE
React Wooden Tree Version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-final-form": "^4.1.0",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.0.3",
+    "react-wooden-tree": "^2.0.5",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"


### PR DESCRIPTION
Updated the `react-wooden-tree` component.

The changes (`2.0.4`) can be reviewed here: https://github.com/brumik/react-wooden-tree/commit/bda97c5281a7cd690097013f9ae745e1ed207f67

The new version does not throw the error about the `UNSAFE_componentWillUpdate` method.

**Long story short:** a variable was passed down to all nodes and on prop change, it needed to be updated explicitly in the `componentWillChange` function. Now it is not necessary since I changed this variable to a context and all the nodes are consuming this context.

Version `2.0.5` introduces better CSS name convention and uses only padding instead of margin.
https://github.com/brumik/react-wooden-tree/commit/1f958cdb08b2119fc99dad5b5695a8e9c52b7205

There should be no performance change.

@miq-bot add_reviewer @karelhala
@skateman 