### PR TITLE
React Tree Component - selected styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-final-form": "^4.1.0",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.0.3",
+    "react-wooden-tree": "^2.0.5",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"

--- a/src/wooden-tree/index.scss
+++ b/src/wooden-tree/index.scss
@@ -1,13 +1,19 @@
-.Tree {
-  .Icon {
-    margin-right: 0;
+.react-tree-view {
+  ul {
+    padding-left: 0;
   }
 
-  .NoOpenButton {
-    margin-left: 1em;
+  li :first-child {
+    padding-left: 1em;
+    display: inline-block;
   }
 
   .dirty {
     color: #39A5DC;
+  }
+
+  .selected {
+    background-color: #349ad3;
+    color: #FFFFFF;
   }
 }

--- a/src/wooden-tree/stories/WoodenTree.stories.js
+++ b/src/wooden-tree/stories/WoodenTree.stories.js
@@ -8,6 +8,7 @@ import { generator, flatLazyChildren } from './Generator';
 import { ReduxTree } from './components/ReduxTree';
 import { ConnectedNode } from './components/ReduxNode';
 import combinedReducers from './reducers';
+import '../index.scss';
 
 /** Create the tree from hierarchical data */
 const tree = Tree.convertHierarchicalTree(Tree.initHierarchicalTree(generator()));
@@ -63,6 +64,7 @@ class App extends React.Component {
         checkboxFirst
         connectedNode={ConnectedNode}
         nodeIcon="fa fa-file-o"
+        selectedIcon="fa"
         callbacks={
           {
             onDataChange: this.onDataChange,


### PR DESCRIPTION
Updated the selected style to match the old version design: using highlight rather than an extra icon. It also removes the huge extra space created by the `<ul> element. `The select now (again) looks like this:

![Screenshot from 2019-11-07 13-15-37](https://user-images.githubusercontent.com/8531681/68388363-bb5ace00-0160-11ea-9a78-636a82e39008.png)

**Before**
![Screenshot from 2019-11-07 13-24-28](https://user-images.githubusercontent.com/8531681/68388920-fc071700-0161-11ea-8cb7-8c978677eee9.png)

The version update of the react-wooden-tree is described here: https://github.com/ManageIQ/react-ui-components/pull/159

@miq-bot add_reviewer @skateman 
@miq-bot add_reviewer @karelhala
