### PR TITLE
Wooden tree fixes (CSS and bugfix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-final-form": "^4.1.0",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.0.5",
+    "react-wooden-tree": "^2.0.9",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-final-form": "^4.1.0",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.0.9",
+    "react-wooden-tree": "^2.0.11",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"

--- a/src/wooden-tree/index.scss
+++ b/src/wooden-tree/index.scss
@@ -8,6 +8,10 @@
     display: inline-block;
   }
 
+  i.icon {
+    box-sizing: content-box;
+  }
+
   .dirty {
     color: #39A5DC;
   }


### PR DESCRIPTION
1. Some pages in ManageIQ caused the tree unexpected visual changes. This commit fixes it.
**Before**: ![Screenshot from 2019-11-19 12-33-50](https://user-images.githubusercontent.com/8531681/69143436-42953380-0ac9-11ea-9655-63c3b9404e30.png) **After**: ![Screenshot from 2019-11-19 12-35-46](https://user-images.githubusercontent.com/8531681/69143447-4a54d800-0ac9-11ea-9895-0e7b9f8cd4c5.png)


2. The `react-wooden-tree` component had a bug with default value: https://github.com/brumik/react-wooden-tree/pull/35 and a checkable bug: https://github.com/brumik/react-wooden-tree/pull/38

3. `react-wooden-tree`: rendering HTML: https://github.com/brumik/react-wooden-tree/pull/41