### PR TITLE
Display blue text for a link, in SimpleTable component

### DIFF
--- a/src/textual_summary/data/simple_table.js
+++ b/src/textual_summary/data/simple_table.js
@@ -3,7 +3,7 @@ export const simpleTableData = {
   rows: [
     [null, '-1', 'outbound', 0, 0, '0.0.0.0/0'],
     [null, 'TCP', 'inbound', 22, 22, '0.0.0.0/0'],
-    [null, 'TCP', 'inbound', 80, 80, '0.0.0.0/0'],
+    [null, {value: ['TCP'], link: 'some_link'}, 'inbound', 80, 80, '0.0.0.0/0'],
   ],
   title: 'Firewall Rules',
 };

--- a/src/textual_summary/simple_table.jsx
+++ b/src/textual_summary/simple_table.jsx
@@ -28,7 +28,7 @@ export default function SimpleTable(props) {
       );
     } else if ((value != null) && (typeof value === 'object') && value.link) {
       // value with a link
-      return <td onClick={e => onClick(value, e)} key={j}>{value.value}</td>;
+      return <td className="btn-link" onClick={e => onClick(value, e)} key={j}>{value.value}</td>;
     }
     // simple value
     return <td className="no-hover" key={j}>{value}</td>;

--- a/src/textual_summary/tests/__snapshots__/simple_table.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/simple_table.test.js.snap
@@ -33,7 +33,12 @@ exports[`Simple Table renders just fine... 1`] = `
       ],
       Array [
         null,
-        "TCP",
+        Object {
+          "link": "some_link",
+          "value": Array [
+            "TCP",
+          ],
+        },
         "inbound",
         80,
         80,
@@ -215,8 +220,9 @@ exports[`Simple Table renders just fine... 1`] = `
           key="0"
         />
         <td
-          className="no-hover"
+          className="btn-link"
           key="1"
+          onClick={[Function]}
         >
           TCP
         </td>


### PR DESCRIPTION
**Issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6572

This PR fixes the issue with the link to _Pod_ which did not look like a link, in the _Build Instances_ table in textual summary of selected _Container Build_.

**Before:**
![before](https://user-images.githubusercontent.com/13417815/71902275-03e33780-3162-11ea-8788-9c9875e10386.png)

**After:**
![after1](https://user-images.githubusercontent.com/13417815/71902290-0ba2dc00-3162-11ea-8d4f-1fadf4c4f921.png)
![after2](https://user-images.githubusercontent.com/13417815/71902299-0e053600-3162-11ea-95a8-3895ea5d0e99.png)

