### PR TITLE
Update SimpleTable PropTypes for label prop and prevent warning

### DIFF
--- a/src/textual_summary/simple_table.jsx
+++ b/src/textual_summary/simple_table.jsx
@@ -55,7 +55,10 @@ export default function SimpleTable(props) {
 
 SimpleTable.propTypes = {
   title: PropTypes.string.isRequired,
-  labels: PropTypes.arrayOf(PropTypes.string).isRequired,
+  labels: PropTypes.arrayOf(PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({ value: PropTypes.string.isRequired, sortable: PropTypes.string }),
+  ])).isRequired,
   rows: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)).isRequired,
   onClick: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
**Related issue:** https://github.com/ManageIQ/manageiq-ui-classic/issues/6572

More issues occurred in Container Build's textual summary page. One of them was the warning:
```
Warning: Failed prop type: Invalid prop `labels[7]` of type `object` supplied to `SimpleTable`, expected `string`.
```
![prop_before](https://user-images.githubusercontent.com/13417815/71900334-ead88780-315d-11ea-9cf7-b6a881899455.png)

This was caused by object present in the data for labels for _Build Instances_ table, instead of expected string [here](https://github.com/ManageIQ/manageiq-ui-classic/blob/master/app/helpers/container_build_helper/textual_summary.rb#L30). The data is ok, so we needed just to edit the _propTypes_ of `SimpleTable` component, to accept such a data and to prevent the warning.
