### PR TITLE
Make searching through Tag categories and values work

### DIFF
--- a/src/tagging/components/InnerComponents/TagSelector.js
+++ b/src/tagging/components/InnerComponents/TagSelector.js
@@ -55,6 +55,7 @@ class TagSelector extends React.Component {
         id="tag_cat"
         // clearable={false}
         simpleValue={false}
+        searchable
       />
     );
   }

--- a/src/tagging/components/InnerComponents/ValueSelector.js
+++ b/src/tagging/components/InnerComponents/ValueSelector.js
@@ -48,6 +48,7 @@ class ValueSelector extends React.Component {
       multi={this.props.multiValue}
       simpleValue
       clearable
+      searchable={values.length > 0}
       placeholder={__('Select tag value')}
     />
   );

--- a/src/tagging/tests/__snapshots__/tag.selector.test.js.snap
+++ b/src/tagging/tests/__snapshots__/tag.selector.test.js.snap
@@ -30,6 +30,7 @@ exports[`Tagging modifier match snapshot 1`] = `
     ]
   }
   placeholder="Select tag category"
+  searchable={true}
   simpleValue={false}
 />
 `;

--- a/src/tagging/tests/__snapshots__/value.selector.test.js.snap
+++ b/src/tagging/tests/__snapshots__/value.selector.test.js.snap
@@ -25,6 +25,7 @@ exports[`match snapshot 1`] = `
     ]
   }
   placeholder="Select tag value"
+  searchable={true}
   simpleValue={true}
 />
 `;
@@ -54,6 +55,7 @@ exports[`match snapshot without multiple values 1`] = `
     ]
   }
   placeholder="Select tag value"
+  searchable={true}
   simpleValue={true}
 />
 `;


### PR DESCRIPTION
**Related BZ:** https://bugzilla.redhat.com/show_bug.cgi?id=1797737

The related BZ says about a different bug (found in CFME 5.11/ivanchuk) but we need changes in this PR to be able to reproduce (and to fix) that bug also on the newest master, where we were not able to search for categories or values at all, while tagging selected items, because `isSearchable` was always set to `false`.

---

**Before:**
Selecting Tag Category:
![category_before](https://user-images.githubusercontent.com/13417815/74464211-6df2a900-4e93-11ea-8270-199e23535f31.png)
Selecting Tag Value:
![value_before](https://user-images.githubusercontent.com/13417815/74464216-70ed9980-4e93-11ea-8d44-864f97dd17fd.png)

**After:**
![category_after](https://user-images.githubusercontent.com/13417815/74464288-8c58a480-4e93-11ea-9f48-19286a24b802.png)
If there is no _Category_ chosen yet, there is no reason to search through values:
![value1_after](https://user-images.githubusercontent.com/13417815/74464263-84006980-4e93-11ea-9888-5ec62f2fb286.png)
![value2_after](https://user-images.githubusercontent.com/13417815/74464271-86fb5a00-4e93-11ea-9eaa-c88b8b870fde.png)
