### PR TITLE
Make repeatedly searching through Tag Categories and Values work

### DIFF
--- a/src/forms/select-styles.js
+++ b/src/forms/select-styles.js
@@ -202,7 +202,7 @@ const customStyles = {
     const valueStub = {
       content: !isMulti // eslint-disable-line no-nested-ternary
         ? showPlaceholder ? `"${placeholder}"` // eslint-disable-line no-nested-ternary
-          : showValue ? `"${value[0].label}"` : '""' : '""',
+          : showValue ? `"${value.label}"` : '""' : '""',
       color: showPlaceholder ? '#999999' : '#363636',
       fontWeight: '600',
       minHeight: 20,


### PR DESCRIPTION
**Fixes:** https://bugzilla.redhat.com/show_bug.cgi?id=1797737
DEPENDS ON: https://github.com/ManageIQ/react-ui-components/pull/166 (merged)

There was an error regarding undefined `value[0]` after repeatedly searching through Tag Categories or Values. This was because `value` is an object with `label` and `value` keys, so using `value.label` instead of `value[0].label` works fine.

The bug was introduced in https://github.com/ManageIQ/react-ui-components/pull/109.

**Before:**
![tag-before](https://user-images.githubusercontent.com/13417815/74664961-07290480-519f-11ea-9862-3a2e35f71fe7.png)

**After:**
![tag-after](https://user-images.githubusercontent.com/13417815/74664966-0abc8b80-519f-11ea-94e2-5ee2c109d696.png)
