### PR TITLE
Fix react-wooden-tree icon size

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "react-final-form": "^4.1.0",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.1.3",
+    "react-wooden-tree": "^2.1.4",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"

--- a/src/wooden-tree/index.scss
+++ b/src/wooden-tree/index.scss
@@ -4,12 +4,15 @@
   }
 
   li :first-child {
-    padding-left: 1em;
     display: inline-block;
   }
 
   i.icon {
+    width: 1em;
     box-sizing: content-box;
+    padding: 2px;
+    padding-right: 1px;
+    margin-right: 4px;
   }
 
   .dirty {

--- a/src/wooden-tree/stories/Generator.js
+++ b/src/wooden-tree/stories/Generator.js
@@ -73,6 +73,8 @@ export function generator() {
         {
           text: 'Child 2 - Changed background color',
           icon: 'fa fa-circle',
+          iconBackground: 'green',
+          iconColor: 'red',
         },
       ],
     },


### PR DESCRIPTION
@miq-bot add_reviewer @mzazrivec 
@miq-bot add_label dependencies

**Before**
<img width="527" alt="cc" src="https://user-images.githubusercontent.com/8531681/78135131-aa696c80-7421-11ea-92b2-10bd74fb3b93.png">

**After**
![Screenshot from 2020-04-07 14-16-58](https://user-images.githubusercontent.com/8531681/78668159-7a671100-78da-11ea-9943-49d7bf616145.png)

**Reference**
![Screenshot from 2020-04-07 17-27-09](https://user-images.githubusercontent.com/8531681/78688029-169e1180-78f5-11ea-8e89-26219b9234cf.png)

**Note**: @skateman In the original tree all the icons are white not just the highlighted, but the new tree does not receive `iconColor` prop to paint them white.