### PR TITLE
Update react-wooden-tree to 2.1.5, remove extra css

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-bootstrap": "^0.32.1",
     "react-redux": "^5.0.6",
     "react-select": "^2.4.2",
-    "react-wooden-tree": "^2.1.4",
+    "react-wooden-tree": "^2.1.5",
     "redux": "^4.0.0",
     "redux-form-validators": "^2.7.0",
     "redux-mock-store": "^1.5.1"

--- a/src/wooden-tree/index.scss
+++ b/src/wooden-tree/index.scss
@@ -3,18 +3,6 @@
     padding-left: 0;
   }
 
-  li :first-child {
-    display: inline-block;
-  }
-
-  i.icon {
-    width: 1em;
-    box-sizing: content-box;
-    padding: 2px;
-    padding-right: 1px;
-    margin-right: 4px;
-  }
-
   .dirty {
     color: #39A5DC;
   }


### PR DESCRIPTION
Adresses the tree alignment issue mentioned in https://github.com/ManageIQ/manageiq-ui-classic/pull/6413#issuecomment-631674370 ,
by updating to react-wooden-tree 2.1.5 (https://github.com/brumik/react-wooden-tree/pull/50),
and removing content-box css that's no longer needed.

Before..

![before1](https://user-images.githubusercontent.com/289743/84080781-3e305980-a9cc-11ea-9e7c-d872f7661a30.png) ![before2](https://user-images.githubusercontent.com/289743/84080783-3ffa1d00-a9cc-11ea-86a7-7763e34166f3.png)


After..

![after1](https://user-images.githubusercontent.com/289743/84080487-c6622f00-a9cb-11ea-92ec-c1b905c43d82.png) ![after2](https://user-images.githubusercontent.com/289743/84080490-c82bf280-a9cb-11ea-8cbf-03c97704e5a1.png)
