### PR TITLE
Do not show hand pointer when links are not clickable

### DIFF
--- a/src/textual_summary/tag_group.jsx
+++ b/src/textual_summary/tag_group.jsx
@@ -19,7 +19,7 @@ export default class TagGroup extends React.Component {
    * Render a simple row. Label, icon, value.
    */
   renderTagRowSimple = item => (
-    <tr key={item.key}>
+    <tr key={item.key} className={item.link ? '' : 'no-hover'}>
       <td className="label">{item.label}</td>
       <td title={item.title} onClick={e => this.checkLinkItem(item, e)}>
         <IconOrImage icon={item.icon} image={item.image} title={item.title} />
@@ -66,7 +66,7 @@ export default class TagGroup extends React.Component {
   renderTagRowMultivalue = item => (
     <React.Fragment key={item.key}>
       {item.value.map((subitem, index) => (
-        <tr key={index}>
+        <tr key={index} className={item.link ? '' : 'no-hover'}>
           {(index === 0) && (
           <td rowSpan={item.value.length} className="label" title={item.title}>{item.label}</td>
             )}

--- a/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
@@ -79,6 +79,7 @@ exports[`TagGroup renders just fine 1`] = `
     </thead>
     <tbody>
       <tr
+        className="no-hover"
         key="0"
       >
         <td
@@ -104,6 +105,7 @@ exports[`TagGroup renders just fine 1`] = `
         </td>
       </tr>
       <tr
+        className="no-hover"
         key="0"
       >
         <td
@@ -133,6 +135,7 @@ exports[`TagGroup renders just fine 1`] = `
         </td>
       </tr>
       <tr
+        className="no-hover"
         key="1"
       >
         <td
@@ -160,6 +163,7 @@ exports[`TagGroup renders just fine 1`] = `
         </td>
       </tr>
       <tr
+        className="no-hover"
         key="0"
       >
         <td
@@ -190,6 +194,7 @@ exports[`TagGroup renders just fine 1`] = `
         </td>
       </tr>
       <tr
+        className="no-hover"
         key="1"
       >
         <td
@@ -221,6 +226,7 @@ exports[`TagGroup renders just fine 1`] = `
         </td>
       </tr>
       <tr
+        className="no-hover"
         key="2"
       >
         <td

--- a/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
@@ -1575,6 +1575,7 @@ exports[`TextualSummary renders just fine 1`] = `
               </thead>
               <tbody>
                 <tr
+                  className="no-hover"
                   key="0"
                 >
                   <td
@@ -1600,6 +1601,7 @@ exports[`TextualSummary renders just fine 1`] = `
                   </td>
                 </tr>
                 <tr
+                  className="no-hover"
                   key="1"
                 >
                   <td


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/7216

before
![before](https://user-images.githubusercontent.com/3450808/92158879-8a880b80-edfa-11ea-859b-3d3460316ac6.png)

after
![after](https://user-images.githubusercontent.com/3450808/92158895-8eb42900-edfa-11ea-8f59-b0f9a8ef8f4a.png)
