### PR TITLE
Disable an active twostate button

### DIFF
--- a/src/toolbar/ToolbarView.jsx
+++ b/src/toolbar/ToolbarView.jsx
@@ -19,6 +19,7 @@ export const ToolbarView = ({ views, onClick }) => (
           data-send_checked={view.send_checked ? 'true' : ''}
           data-prompt={view.prompt}
           data-popup={view.popup}
+          disabled={!view.enabled}
           onClick={() => onClick(view)}
         >
           <i className={view.icon} style={{ color: adjustColor(view.color, view.enabled) }} />


### PR DESCRIPTION
Even tho button was active, user could re-click on it, this fix disables the button when it is active to eliminate the confusion.

Fixes https://github.com/ManageIQ/manageiq-ui-classic/issues/491

After fix
![Screenshot from 2020-09-03 16-11-30](https://user-images.githubusercontent.com/3450808/92164271-1aca4e80-ee03-11ea-9cba-d22a99967f5f.png)

![Screenshot from 2020-09-03 16-11-04](https://user-images.githubusercontent.com/3450808/92164276-1b62e500-ee03-11ea-98e5-d49c662cf2a9.png)
