### PR TITLE
Fix links color and A11y in table summary page

### DIFF
--- a/src/textual_summary/generic_table_row.jsx
+++ b/src/textual_summary/generic_table_row.jsx
@@ -33,12 +33,22 @@ export default function GenericTableRow(props) {
   const value = renderValue(item.value, props.onClick);
 
   return (
-    <tr onClick={e => props.onClick(item, e)} className={item.hoverClass} title={item.title}>
+    <tr className={item.hoverClass} title={item.title}>
       <td className="label">{item.label}</td>
+      {item.link &&
+      <td>
+        <a href={item.link} onClick={e => props.onClick(item, e)}>
+          <IconOrImage icon={item.icon} image={item.image} title={item.title} background={item.background} />
+          {item.button ? <Button bsSize="small">{value}</Button> : value}
+        </a>
+      </td>
+      }
+      {(item.link === undefined) &&
       <td>
         <IconOrImage icon={item.icon} image={item.image} title={item.title} background={item.background} />
         {item.button ? <Button bsSize="small">{value}</Button> : value}
       </td>
+      }
     </tr>
   );
 }

--- a/src/textual_summary/multilink_table.jsx
+++ b/src/textual_summary/multilink_table.jsx
@@ -9,10 +9,11 @@ export default function MultilinkTable(props) {
       title={sub.title}
       className="hover"
       style={{ cursor: 'pointer, hand' }}
-      onClick={e => onClick(sub, e)}
     >
-      <IconOrImage icon={sub.icon} image={sub.image} title={sub.title} />
-      {sub.value}
+      <a href={sub.link} onClick={e => onClick(sub, e)}>
+        <IconOrImage icon={sub.icon} image={sub.image} title={sub.title} />
+        {sub.value}
+      </a>
     </td>
   );
 

--- a/src/textual_summary/simple_table.jsx
+++ b/src/textual_summary/simple_table.jsx
@@ -28,7 +28,7 @@ export default function SimpleTable(props) {
       );
     } else if ((value != null) && (typeof value === 'object') && value.link) {
       // value with a link
-      return <td className="btn-link" onClick={e => onClick(value, e)} key={j}>{value.value}</td>;
+      return <td key={j} className="btn-link" ><a href={value.link} onClick={e => onClick(value, e)}>{value.value}</a></td>;
     }
     // simple value
     return <td className="no-hover" key={j}>{value}</td>;

--- a/src/textual_summary/table_list_view.jsx
+++ b/src/textual_summary/table_list_view.jsx
@@ -8,9 +8,11 @@ const simpleRow = (row, i, colOrder) => (
 );
 
 const clickableRow = (row, i, colOrder, rowLabel, onClick) => (
-  <tr key={i} onClick={e => onClick(row, e)}>
-    {colOrder.map((col, j) => <td key={j} title={rowLabel}>{`${row[col]}`}</td>)}
-  </tr>
+  <a href={row.link} onClick={e => onClick(row, e)}>
+    <tr key={i} >
+      {colOrder.map((col, j) => <td key={j} title={rowLabel}>{`${row[col]}`}</td>)}
+    </tr>
+  </a>
 );
 
 const renderRow = (row, i, colOrder, rowLabel, onClick) => (

--- a/src/textual_summary/tag_group.jsx
+++ b/src/textual_summary/tag_group.jsx
@@ -7,25 +7,27 @@ import IconOrImage from './icon_or_image';
  */
 export default class TagGroup extends React.Component {
   /**
-   * Return onClick function if link is defined for an item/subitem
-   */
-  checkLinkItem = (item, e) => {
-    if (item.link && this.props.onClick) {
-      this.props.onClick(item, e);
-    }
-  }
-
-  /**
    * Render a simple row. Label, icon, value.
    */
   renderTagRowSimple = item => (
     <tr key={item.key} className={item.link ? '' : 'no-hover'}>
       <td className="label">{item.label}</td>
-      <td title={item.title} onClick={e => this.checkLinkItem(item, e)}>
+      {(item.link && this.props.onClick) &&
+      <td title={item.title}>
+        <a href={item.link} onClick={e => this.props.onClick(item, e)}>
+          <IconOrImage icon={item.icon} image={item.image} title={item.title} />
+          {' '}
+          {item.value}
+        </a>
+      </td>
+      }
+      {(item.link === undefined) &&
+      <td title={item.title}>
         <IconOrImage icon={item.icon} image={item.image} title={item.title} />
         {' '}
         {item.value}
       </td>
+      }
     </tr>
   );
 
@@ -70,10 +72,20 @@ export default class TagGroup extends React.Component {
           {(index === 0) && (
           <td rowSpan={item.value.length} className="label" title={item.title}>{item.label}</td>
             )}
-          <td title={subitem.title} onClick={e => this.checkLinkItem(subitem, e)}>
+          {(subitem.link && this.props.onClick) &&
+          <td title={subitem.title}>
+            <a href={subitem.link} onClick={e => this.props.onClick(subitem, e)}>
+              <IconOrImage icon={subitem.icon} image={subitem.image} text={subitem.text} />
+              {Array.isArray(subitem.value) ? this.renderSubitemList(subitem) : this.renderSubitem(subitem)}
+            </a>
+          </td>
+      }
+          {(subitem.link === undefined) &&
+          <td title={subitem.title}>
             <IconOrImage icon={subitem.icon} image={subitem.image} text={subitem.text} />
             {Array.isArray(subitem.value) ? this.renderSubitemList(subitem) : this.renderSubitem(subitem)}
           </td>
+      }
         </tr>
         ))}
     </React.Fragment>

--- a/src/textual_summary/tests/__snapshots__/generic_group.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/generic_group.test.js.snap
@@ -46,7 +46,6 @@ exports[`GenericGroup renders just fine 1`] = `
       >
         <tr
           className="bar"
-          onClick={[Function]}
         >
           <td
             className="label"
@@ -79,7 +78,6 @@ exports[`GenericGroup renders just fine 1`] = `
       >
         <tr
           className="bar"
-          onClick={[Function]}
         >
           <td
             className="label"

--- a/src/textual_summary/tests/__snapshots__/generic_table_row.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/generic_table_row.test.js.snap
@@ -30,7 +30,6 @@ exports[`Simple Table renders multi-value just fine... 1`] = `
     >
       <tr
         className=""
-        onClick={[Function]}
         title="Show Network Manager 'Amazon East Network Manager'"
       >
         <td
@@ -39,70 +38,75 @@ exports[`Simple Table renders multi-value just fine... 1`] = `
           Network Manager
         </td>
         <td>
-          <IconOrImage
-            icon={null}
-            image="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
-            title="Show Network Manager 'Amazon East Network Manager'"
+          <a
+            href="/ems_network/10000000000045"
+            onClick={[Function]}
           >
-            <img
-              alt="Show Network Manager 'Amazon East Network Manager'"
-              src="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
+            <IconOrImage
+              icon={null}
+              image="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
               title="Show Network Manager 'Amazon East Network Manager'"
-            />
-          </IconOrImage>
-          <table
-            cellPadding="0"
-            cellSpacing="0"
-          >
-            <tbody>
-              <tr
-                className="no-hover"
-                key="0"
-                onClick={[Function]}
-                title="Amazon East Network Manager"
-              >
-                <td
-                  style={
-                    Object {
-                      "border": 0,
-                      "margin": 0,
-                      "padding": 0,
-                    }
-                  }
+            >
+              <img
+                alt="Show Network Manager 'Amazon East Network Manager'"
+                src="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
+                title="Show Network Manager 'Amazon East Network Manager'"
+              />
+            </IconOrImage>
+            <table
+              cellPadding="0"
+              cellSpacing="0"
+            >
+              <tbody>
+                <tr
+                  className="no-hover"
+                  key="0"
+                  onClick={[Function]}
+                  title="Amazon East Network Manager"
                 >
-                  <IconOrImage
-                    icon={null}
-                    image={null}
-                    title="Amazon East Network Manager"
-                  />
-                  foobar
-                </td>
-              </tr>
-              <tr
-                className="no-hover"
-                key="1"
-                onClick={[Function]}
-                title="Amazon West Network Manager"
-              >
-                <td
-                  style={
-                    Object {
-                      "border": 0,
-                      "margin": 0,
-                      "padding": 0,
+                  <td
+                    style={
+                      Object {
+                        "border": 0,
+                        "margin": 0,
+                        "padding": 0,
+                      }
                     }
-                  }
+                  >
+                    <IconOrImage
+                      icon={null}
+                      image={null}
+                      title="Amazon East Network Manager"
+                    />
+                    foobar
+                  </td>
+                </tr>
+                <tr
+                  className="no-hover"
+                  key="1"
+                  onClick={[Function]}
+                  title="Amazon West Network Manager"
                 >
-                  <IconOrImage
-                    icon={null}
-                    image={null}
-                    title="Amazon West Network Manager"
-                  />
-                  boofar
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                  <td
+                    style={
+                      Object {
+                        "border": 0,
+                        "margin": 0,
+                        "padding": 0,
+                      }
+                    }
+                  >
+                    <IconOrImage
+                      icon={null}
+                      image={null}
+                      title="Amazon West Network Manager"
+                    />
+                    boofar
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </a>
         </td>
       </tr>
     </GenericTableRow>
@@ -129,7 +133,6 @@ exports[`Simple Table renders simple value just fine... 1`] = `
     >
       <tr
         className=""
-        onClick={[Function]}
         title="Show Network Manager 'Amazon East Network Manager'"
       >
         <td
@@ -138,21 +141,26 @@ exports[`Simple Table renders simple value just fine... 1`] = `
           Network Manager
         </td>
         <td>
-          <IconOrImage
-            icon={null}
-            image="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
-            title="Show Network Manager 'Amazon East Network Manager'"
+          <a
+            href="/ems_network/10000000000045"
+            onClick={[Function]}
           >
-            <img
-              alt="Show Network Manager 'Amazon East Network Manager'"
-              src="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
+            <IconOrImage
+              icon={null}
+              image="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
               title="Show Network Manager 'Amazon East Network Manager'"
-            />
-          </IconOrImage>
-          <span>
-             
-            Amazon East Network Manager
-          </span>
+            >
+              <img
+                alt="Show Network Manager 'Amazon East Network Manager'"
+                src="http://localhost:3000/assets/svg/vendor-ec2_network-04c432db85be0fd670cd6da83b8685dab51e1b7a63258b70cccbdf8d7f72c988.svg"
+                title="Show Network Manager 'Amazon East Network Manager'"
+              />
+            </IconOrImage>
+            <span>
+               
+              Amazon East Network Manager
+            </span>
+          </a>
         </td>
       </tr>
     </GenericTableRow>

--- a/src/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/multilink_table.test.js.snap
@@ -300,7 +300,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -308,17 +307,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Aodh"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Aodh"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=1&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Aodh"
-            />
-          </IconOrImage>
-          Running (3)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Aodh"
+              />
+            </IconOrImage>
+            Running (3)
+          </a>
         </td>
         <td
           key="1"
@@ -334,7 +338,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -342,17 +345,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Aodh"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Aodh"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=1&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Aodh"
-            />
-          </IconOrImage>
-          All (3)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Aodh"
+              />
+            </IconOrImage>
+            All (3)
+          </a>
         </td>
         <td
           key="3"
@@ -388,7 +396,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -396,17 +403,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Ceilometer"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Ceilometer"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=2&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Ceilometer"
-            />
-          </IconOrImage>
-          Running (3)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Ceilometer"
+              />
+            </IconOrImage>
+            Running (3)
+          </a>
         </td>
         <td
           key="1"
@@ -422,7 +434,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -430,17 +441,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Ceilometer"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Ceilometer"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=2&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Ceilometer"
-            />
-          </IconOrImage>
-          All (3)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Ceilometer"
+              />
+            </IconOrImage>
+            All (3)
+          </a>
         </td>
         <td
           key="3"
@@ -476,7 +492,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -484,17 +499,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Cinder"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Cinder"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=3&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Cinder"
-            />
-          </IconOrImage>
-          Running (3)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Cinder"
+              />
+            </IconOrImage>
+            Running (3)
+          </a>
         </td>
         <td
           key="1"
@@ -510,7 +530,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -518,17 +537,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Cinder"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Cinder"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=3&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Cinder"
-            />
-          </IconOrImage>
-          All (3)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Cinder"
+              />
+            </IconOrImage>
+            All (3)
+          </a>
         </td>
         <td
           key="3"
@@ -564,7 +588,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -572,17 +595,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Glance"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Glance"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=4&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Glance"
-            />
-          </IconOrImage>
-          Running (2)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Glance"
+              />
+            </IconOrImage>
+            Running (2)
+          </a>
         </td>
         <td
           key="1"
@@ -598,7 +626,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -606,17 +633,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Glance"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Glance"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=4&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Glance"
-            />
-          </IconOrImage>
-          All (2)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Glance"
+              />
+            </IconOrImage>
+            All (2)
+          </a>
         </td>
         <td
           key="3"
@@ -652,7 +684,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -660,17 +691,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Gnocchi"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Gnocchi"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=5&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Gnocchi"
-            />
-          </IconOrImage>
-          Running (2)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Gnocchi"
+              />
+            </IconOrImage>
+            Running (2)
+          </a>
         </td>
         <td
           key="1"
@@ -686,7 +722,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -694,17 +729,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Gnocchi"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Gnocchi"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=5&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Gnocchi"
-            />
-          </IconOrImage>
-          All (2)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Gnocchi"
+              />
+            </IconOrImage>
+            All (2)
+          </a>
         </td>
         <td
           key="3"
@@ -740,7 +780,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -748,17 +787,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Heat"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Heat"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=6&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Heat"
-            />
-          </IconOrImage>
-          Running (4)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Heat"
+              />
+            </IconOrImage>
+            Running (4)
+          </a>
         </td>
         <td
           key="1"
@@ -774,7 +818,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -782,17 +825,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Heat"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Heat"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=6&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Heat"
-            />
-          </IconOrImage>
-          All (4)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Heat"
+              />
+            </IconOrImage>
+            All (4)
+          </a>
         </td>
         <td
           key="3"
@@ -850,7 +898,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -858,17 +905,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Keystone"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Keystone"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=7&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Keystone"
-            />
-          </IconOrImage>
-          All (1)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Keystone"
+              />
+            </IconOrImage>
+            All (1)
+          </a>
         </td>
         <td
           key="3"
@@ -904,7 +956,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -912,17 +963,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Nova"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Nova"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=8&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Nova"
-            />
-          </IconOrImage>
-          Running (5)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Nova"
+              />
+            </IconOrImage>
+            Running (5)
+          </a>
         </td>
         <td
           key="1"
@@ -938,7 +994,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -946,17 +1001,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Nova"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Nova"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=8&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Nova"
-            />
-          </IconOrImage>
-          All (10)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Nova"
+              />
+            </IconOrImage>
+            All (10)
+          </a>
         </td>
         <td
           key="3"
@@ -992,7 +1052,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="0"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -1000,17 +1059,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of running Swift"
         >
-          <IconOrImage
-            icon="pficon pficon-ok"
-            image={null}
-            title="Show list of running Swift"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=9&status=running"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-ok"
+            <IconOrImage
+              icon="pficon pficon-ok"
+              image={null}
               title="Show list of running Swift"
-            />
-          </IconOrImage>
-          Running (14)
+            >
+              <i
+                className="pficon pficon-ok"
+                title="Show list of running Swift"
+              />
+            </IconOrImage>
+            Running (14)
+          </a>
         </td>
         <td
           key="1"
@@ -1026,7 +1090,6 @@ exports[`MultilinkTable renders just fine 1`] = `
         <td
           className="hover"
           key="2"
-          onClick={[Function]}
           style={
             Object {
               "cursor": "pointer, hand",
@@ -1034,17 +1097,22 @@ exports[`MultilinkTable renders just fine 1`] = `
           }
           title="Show list of all Swift"
         >
-          <IconOrImage
-            icon="pficon pficon-service"
-            image={null}
-            title="Show list of all Swift"
+          <a
+            href="/host/host_services/18?db=host&host_service_group=9&status=all"
+            onClick={[Function]}
           >
-            <i
-              className="pficon pficon-service"
+            <IconOrImage
+              icon="pficon pficon-service"
+              image={null}
               title="Show list of all Swift"
-            />
-          </IconOrImage>
-          All (14)
+            >
+              <i
+                className="pficon pficon-service"
+                title="Show list of all Swift"
+              />
+            </IconOrImage>
+            All (14)
+          </a>
         </td>
         <td
           key="3"

--- a/src/textual_summary/tests/__snapshots__/simple_table.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/simple_table.test.js.snap
@@ -222,9 +222,13 @@ exports[`Simple Table renders just fine... 1`] = `
         <td
           className="btn-link"
           key="1"
-          onClick={[Function]}
         >
-          TCP
+          <a
+            href="some_link"
+            onClick={[Function]}
+          >
+            TCP
+          </a>
         </td>
         <td
           className="no-hover"

--- a/src/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/table_list_view.test.js.snap
@@ -62,40 +62,48 @@ exports[`TableListView renders just fine... 1`] = `
       </tr>
     </thead>
     <tbody>
-      <tr
-        key="0"
+      <a
+        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000181');"
         onClick={[Function]}
       >
-        <td
+        <tr
           key="0"
-          title="View the table"
         >
-          vim_performance_states
-        </td>
-        <td
-          key="1"
-          title="View the table"
-        >
-          676,150
-        </td>
-      </tr>
-      <tr
-        key="1"
+          <td
+            key="0"
+            title="View the table"
+          >
+            vim_performance_states
+          </td>
+          <td
+            key="1"
+            title="View the table"
+          >
+            676,150
+          </td>
+        </tr>
+      </a>
+      <a
+        href="miqTreeActivateNode('vmdb_tree', 'tb-10000000000197');"
         onClick={[Function]}
       >
-        <td
-          key="0"
-          title="View the table"
-        >
-          miq_report_result_details
-        </td>
-        <td
+        <tr
           key="1"
-          title="View the table"
         >
-          280,848
-        </td>
-      </tr>
+          <td
+            key="0"
+            title="View the table"
+          >
+            miq_report_result_details
+          </td>
+          <td
+            key="1"
+            title="View the table"
+          >
+            280,848
+          </td>
+        </tr>
+      </a>
     </tbody>
   </table>
 </TableListView>

--- a/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/tag_group.test.js.snap
@@ -87,9 +87,7 @@ exports[`TagGroup renders just fine 1`] = `
         >
           Managed by Zone
         </td>
-        <td
-          onClick={[Function]}
-        >
+        <td>
           <IconOrImage
             icon="pficon pficon-zone"
             image={null}
@@ -114,9 +112,7 @@ exports[`TagGroup renders just fine 1`] = `
         >
           My Company X Tags
         </td>
-        <td
-          onClick={[Function]}
-        >
+        <td>
           <IconOrImage
             icon="fa fa-tag"
             image={null}
@@ -138,9 +134,7 @@ exports[`TagGroup renders just fine 1`] = `
         className="no-hover"
         key="1"
       >
-        <td
-          onClick={[Function]}
-        >
+        <td>
           <IconOrImage
             icon="fa fa-tag"
             image={null}
@@ -173,9 +167,7 @@ exports[`TagGroup renders just fine 1`] = `
         >
           Other Tags
         </td>
-        <td
-          onClick={[Function]}
-        >
+        <td>
           <IconOrImage
             icon="fa fa-tag"
             image={null}
@@ -197,9 +189,7 @@ exports[`TagGroup renders just fine 1`] = `
         className="no-hover"
         key="1"
       >
-        <td
-          onClick={[Function]}
-        >
+        <td>
           <IconOrImage
             icon="fa fa-tag"
             image={null}
@@ -228,22 +218,7 @@ exports[`TagGroup renders just fine 1`] = `
       <tr
         className="no-hover"
         key="2"
-      >
-        <td
-          onClick={[Function]}
-          title="Click to display the item"
-        >
-          <IconOrImage
-            icon={null}
-            image={null}
-            title={null}
-          />
-          <span>
-             
-            Demo 3
-          </span>
-        </td>
-      </tr>
+      />
     </tbody>
   </table>
 </TagGroup>

--- a/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
@@ -332,7 +332,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                   >
                     <td
                       className="label"
@@ -365,7 +364,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                   >
                     <td
                       className="label"
@@ -398,7 +396,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                   >
                     <td
                       className="label"
@@ -529,7 +526,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                     title="Ok"
                   >
                     <td
@@ -564,7 +560,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                     title="Ok"
                   >
                     <td
@@ -606,7 +601,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                     title={null}
                   >
                     <td
@@ -686,7 +680,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                   >
                     <td
                       className="label"
@@ -1043,7 +1036,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className="no-hover"
-                    onClick={[Function]}
                   >
                     <td
                       className="label"
@@ -1085,7 +1077,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show all Cloud Networks"
                   >
                     <td
@@ -1094,20 +1085,25 @@ exports[`TextualSummary renders just fine 1`] = `
                       Cloud Networks
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="ff ff-cloud-network"
-                        image={null}
-                        title="Show all Cloud Networks"
+                      <a
+                        href="/ems_network/39?display=cloud_networks"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="ff ff-cloud-network"
+                        <IconOrImage
+                          icon="ff ff-cloud-network"
+                          image={null}
                           title="Show all Cloud Networks"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                        1
-                      </span>
+                        >
+                          <i
+                            className="ff ff-cloud-network"
+                            title="Show all Cloud Networks"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                          1
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1128,7 +1124,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show all Cloud Subnets"
                   >
                     <td
@@ -1137,20 +1132,25 @@ exports[`TextualSummary renders just fine 1`] = `
                       Cloud Subnets
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="pficon pficon-network"
-                        image={null}
-                        title="Show all Cloud Subnets"
+                      <a
+                        href="/ems_network/39?display=cloud_subnets"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="pficon pficon-network"
+                        <IconOrImage
+                          icon="pficon pficon-network"
+                          image={null}
                           title="Show all Cloud Subnets"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                        6
-                      </span>
+                        >
+                          <i
+                            className="pficon pficon-network"
+                            title="Show all Cloud Subnets"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                          6
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1171,7 +1171,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show all Network Routers"
                   >
                     <td
@@ -1180,20 +1179,25 @@ exports[`TextualSummary renders just fine 1`] = `
                       Network Routers
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="pficon pficon-route"
-                        image={null}
-                        title="Show all Network Routers"
+                      <a
+                        href="/ems_network/39?display=network_routers"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="pficon pficon-route"
+                        <IconOrImage
+                          icon="pficon pficon-route"
+                          image={null}
                           title="Show all Network Routers"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                        1
-                      </span>
+                        >
+                          <i
+                            className="pficon pficon-route"
+                            title="Show all Network Routers"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                          1
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1214,7 +1218,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show all Security Groups"
                   >
                     <td
@@ -1223,20 +1226,25 @@ exports[`TextualSummary renders just fine 1`] = `
                       Security Groups
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="pficon pficon-cloud-security"
-                        image={null}
-                        title="Show all Security Groups"
+                      <a
+                        href="/ems_network/39?display=security_groups"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="pficon pficon-cloud-security"
+                        <IconOrImage
+                          icon="pficon pficon-cloud-security"
+                          image={null}
                           title="Show all Security Groups"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                        18
-                      </span>
+                        >
+                          <i
+                            className="pficon pficon-cloud-security"
+                            title="Show all Security Groups"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                          18
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1257,7 +1265,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show all Floating IPs"
                   >
                     <td
@@ -1266,20 +1273,25 @@ exports[`TextualSummary renders just fine 1`] = `
                       Floating IPs
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="ff ff-floating-ip"
-                        image={null}
-                        title="Show all Floating IPs"
+                      <a
+                        href="/ems_network/39?display=floating_ips"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="ff ff-floating-ip"
+                        <IconOrImage
+                          icon="ff ff-floating-ip"
+                          image={null}
                           title="Show all Floating IPs"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                        14
-                      </span>
+                        >
+                          <i
+                            className="ff ff-floating-ip"
+                            title="Show all Floating IPs"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                          14
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1300,7 +1312,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show all Network Ports"
                   >
                     <td
@@ -1309,20 +1320,25 @@ exports[`TextualSummary renders just fine 1`] = `
                       Network Ports
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="ff ff-network-port"
-                        image={null}
-                        title="Show all Network Ports"
+                      <a
+                        href="/ems_network/39?display=network_ports"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="ff ff-network-port"
+                        <IconOrImage
+                          icon="ff ff-network-port"
+                          image={null}
                           title="Show all Network Ports"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                        26
-                      </span>
+                        >
+                          <i
+                            className="ff ff-network-port"
+                            title="Show all Network Ports"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                          26
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1343,7 +1359,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show all Load Balancers"
                   >
                     <td
@@ -1352,20 +1367,25 @@ exports[`TextualSummary renders just fine 1`] = `
                       Load Balancers
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="ff ff-load-balancer"
-                        image={null}
-                        title="Show all Load Balancers"
+                      <a
+                        href="/ems_network/39?display=load_balancers"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="ff ff-load-balancer"
+                        <IconOrImage
+                          icon="ff ff-load-balancer"
+                          image={null}
                           title="Show all Load Balancers"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                        2
-                      </span>
+                        >
+                          <i
+                            className="ff ff-load-balancer"
+                            title="Show all Load Balancers"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                          2
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1385,7 +1405,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                   >
                     <td
                       className="label"
@@ -1487,7 +1506,6 @@ exports[`TextualSummary renders just fine 1`] = `
                 >
                   <tr
                     className=""
-                    onClick={[Function]}
                     title="Show topology"
                   >
                     <td
@@ -1496,19 +1514,24 @@ exports[`TextualSummary renders just fine 1`] = `
                       Topology
                     </td>
                     <td>
-                      <IconOrImage
-                        icon="pficon pficon-topology"
-                        image={null}
-                        title="Show topology"
+                      <a
+                        href="/network_topology/show/39"
+                        onClick={[Function]}
                       >
-                        <i
-                          className="pficon pficon-topology"
+                        <IconOrImage
+                          icon="pficon pficon-topology"
+                          image={null}
                           title="Show topology"
-                        />
-                      </IconOrImage>
-                      <span>
-                         
-                      </span>
+                        >
+                          <i
+                            className="pficon pficon-topology"
+                            title="Show topology"
+                          />
+                        </IconOrImage>
+                        <span>
+                           
+                        </span>
+                      </a>
                     </td>
                   </tr>
                 </GenericTableRow>
@@ -1583,9 +1606,7 @@ exports[`TextualSummary renders just fine 1`] = `
                   >
                     Managed by Zone
                   </td>
-                  <td
-                    onClick={[Function]}
-                  >
+                  <td>
                     <IconOrImage
                       icon="pficon pficon-zone"
                       image={null}
@@ -1609,9 +1630,7 @@ exports[`TextualSummary renders just fine 1`] = `
                   >
                     My Company Tags
                   </td>
-                  <td
-                    onClick={[Function]}
-                  >
+                  <td>
                     <IconOrImage
                       icon="fa fa-tag"
                       image={null}


### PR DESCRIPTION
Clickable items are not identifiable by color (usually they are in different color the UI) and you need to flyover on all fields to check which ones are clickable, links are not accessible with keyboard as well.

Before:
<img width="1424" alt="Screen Shot 2020-11-09 at 8 51 00 AM" src="https://user-images.githubusercontent.com/37085529/98549407-bc897400-2268-11eb-9142-17738ac7926d.png">
 
After:
links are in different color and accessible with keyboard.
<img width="1417" alt="Screen Shot 2020-11-09 at 8 52 28 AM" src="https://user-images.githubusercontent.com/37085529/98549569-fa869800-2268-11eb-9eeb-38739b28fa3e.png">

<img width="1418" alt="Screen Shot 2020-11-09 at 8 52 42 AM" src="https://user-images.githubusercontent.com/37085529/98549589-01150f80-2269-11eb-8ca8-410175bebf48.png">

