### PR TITLE
Introduced CSS Class to Prevent Table Labels Getting Cut Off

### DIFF
--- a/src/textual_summary/generic_table_row.jsx
+++ b/src/textual_summary/generic_table_row.jsx
@@ -34,7 +34,7 @@ export default function GenericTableRow(props) {
 
   return (
     <tr className={item.hoverClass} title={item.title}>
-      <td className="label">{item.label}</td>
+      <td className="label generic-row-label">{item.label}</td>
       {item.link &&
       <td>
         <a href={item.link} onClick={e => props.onClick(item, e)}>

--- a/src/textual_summary/tests/__snapshots__/generic_group.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/generic_group.test.js.snap
@@ -48,7 +48,7 @@ exports[`GenericGroup renders just fine 1`] = `
           className="bar"
         >
           <td
-            className="label"
+            className="label generic-row-label"
           >
             foo
           </td>
@@ -80,7 +80,7 @@ exports[`GenericGroup renders just fine 1`] = `
           className="bar"
         >
           <td
-            className="label"
+            className="label generic-row-label"
           >
             mrkef?
           </td>

--- a/src/textual_summary/tests/__snapshots__/generic_table_row.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/generic_table_row.test.js.snap
@@ -33,7 +33,7 @@ exports[`Simple Table renders multi-value just fine... 1`] = `
         title="Show Network Manager 'Amazon East Network Manager'"
       >
         <td
-          className="label"
+          className="label generic-row-label"
         >
           Network Manager
         </td>
@@ -136,7 +136,7 @@ exports[`Simple Table renders simple value just fine... 1`] = `
         title="Show Network Manager 'Amazon East Network Manager'"
       >
         <td
-          className="label"
+          className="label generic-row-label"
         >
           Network Manager
         </td>

--- a/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
+++ b/src/textual_summary/tests/__snapshots__/textual_summary.test.js.snap
@@ -334,7 +334,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     className="no-hover"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Region
                     </td>
@@ -366,7 +366,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     className="no-hover"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Type
                     </td>
@@ -398,7 +398,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     className="no-hover"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Management Engine GUID
                     </td>
@@ -529,7 +529,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Ok"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Default Credentials
                     </td>
@@ -563,7 +563,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Ok"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       SmartState Docker Credentials
                     </td>
@@ -604,7 +604,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title={null}
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Last Refresh
                     </td>
@@ -682,7 +682,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     className="no-hover"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Last Refresh Date
                     </td>
@@ -1038,7 +1038,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     className="no-hover"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Cloud Tenants
                     </td>
@@ -1080,7 +1080,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show all Cloud Networks"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Cloud Networks
                     </td>
@@ -1127,7 +1127,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show all Cloud Subnets"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Cloud Subnets
                     </td>
@@ -1174,7 +1174,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show all Network Routers"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Network Routers
                     </td>
@@ -1221,7 +1221,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show all Security Groups"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Security Groups
                     </td>
@@ -1268,7 +1268,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show all Floating IPs"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Floating IPs
                     </td>
@@ -1315,7 +1315,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show all Network Ports"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Network Ports
                     </td>
@@ -1362,7 +1362,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show all Load Balancers"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Load Balancers
                     </td>
@@ -1407,7 +1407,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     className=""
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Power State
                     </td>
@@ -1509,7 +1509,7 @@ exports[`TextualSummary renders just fine 1`] = `
                     title="Show topology"
                   >
                     <td
-                      className="label"
+                      className="label generic-row-label"
                     >
                       Topology
                     </td>


### PR DESCRIPTION
Related to: https://github.com/ManageIQ/manageiq-ui-classic/pull/7473

In conjunction with the above PR the `generic-row-label` class prevents the `word-break` property of row labels in textual summary tables for being overridden to `break-all` causing words in the label to get divided onto different lines.

Before:
![image](https://user-images.githubusercontent.com/64800041/103792955-e44f4b00-5011-11eb-8107-a4b4581cc23c.png)
After:
![image](https://user-images.githubusercontent.com/64800041/103792336-83c00e00-5011-11eb-8c5b-17c03cf033a2.png)

